### PR TITLE
Add GitHub API rate limit and authentication status to dashboard. 

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -70,6 +70,7 @@ var analyzeCmd = &cobra.Command{
 		output.PrintLanguages(langs)
 		output.PrintCommitActivity(activity,14)
 		output.PrintHealth(score)
+		output.PrintGitHubAPIStatus(client)
 		output.PrintRecruiterSummary(summary)
 
 		return nil

--- a/internal/github/rate_limit.go
+++ b/internal/github/rate_limit.go
@@ -1,0 +1,25 @@
+package github
+
+import (
+	"time"
+)
+type RateLimit struct {
+	Resources struct {
+		Core struct {
+			Limit     int `json:"limit"`
+			Remaining int `json:"remaining"`
+			Reset     int `json:"reset"`
+		} `json:"core"`
+	} `json:"resources"`
+}
+func (c *Client) GetRateLimit() (*RateLimit, error) {
+	var rateLimit RateLimit
+	err := c.get("https://api.github.com/rate_limit", &rateLimit)
+	if err != nil {
+		return nil, err
+	}
+	return &rateLimit, nil
+}
+func (r *RateLimit) ResetTime() time.Time {
+	return time.Unix(int64(r.Resources.Core.Reset), 0)
+}

--- a/internal/output/health.go
+++ b/internal/output/health.go
@@ -2,9 +2,13 @@ package output
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/agnivo988/Repo-lyzer/internal/github"
 )
+
+
 
 func PrintHealth(score int) {
     color := "#FF5F5F"
@@ -23,4 +27,31 @@ func PrintHealth(score int) {
      fmt.Println(style.Render(
 		fmt.Sprintf("\n🏆 Repo Health Score : %d/100 (%s)\n",score,label),
 	 ))
+}
+func PrintGitHubAPIStatus(client *github.Client) {
+	rateLimit, err := client.GetRateLimit()
+	if err != nil {
+		fmt.Println("⚠️ Unable to fetch GitHub API status")
+		return
+	}
+
+	mode := "Unauthenticated"
+if os.Getenv("GITHUB_TOKEN") != "" {
+	mode = "Authenticated"
+}
+
+
+	style := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7AE7C7"))
+
+	fmt.Println(style.Render("🔐 GitHub API Status"))
+	fmt.Printf("Mode        : %s\n", mode)
+	fmt.Printf(
+		"Requests    : %d / %d\n",
+		rateLimit.Resources.Core.Remaining,
+		rateLimit.Resources.Core.Limit,
+	)
+	fmt.Printf(
+		"Resets At   : %s\n\n",
+		rateLimit.ResetTime().Format("15:04"),
+	)
 }


### PR DESCRIPTION
## Summary
This PR adds visibility into GitHub API usage by displaying authentication mode and rate limit information directly in the Repo-lyzer dashboard.

## What’s Included
- Displays GitHub API authentication status (authenticated vs unauthenticated)
- Shows remaining API requests and total limit
- Displays human-readable rate limit reset time
- Graceful fallback when rate limit data cannot be fetched

## Why This Change
Repo-lyzer relies heavily on the GitHub REST API. Without visibility into rate limits, users may experience silent failures or incomplete data. This enhancement improves transparency and user experience, especially when analyzing or comparing multiple repositories.

## Implementation Details
- Introduced a dedicated rate limit handler in `internal/github`
- Reused existing GitHub client logic for consistency
- Added a lightweight, non-intrusive status section in the output layer
- No breaking changes to existing functionality

## Testing
- Tested locally using `go run main.go analyze owner/repo`
- Verified behavior with and without `GITHUB_TOKEN` set

Fixes #<ISSUE_NUMBER>
