### PR TITLE
fix: Implement Compare Two Repositories feature

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -24,12 +24,17 @@ const (
 	stateHelp
 	stateHistory
 	stateCompareInput
+	stateCompareLoading
+	stateCompareResult
 )
 
 type MainModel struct {
 	state         sessionState
 	menu          MenuModel
 	input         string // Repository input
+	compareInput1 string // First repo for comparison
+	compareInput2 string // Second repo for comparison
+	compareStep   int    // 0 = entering first repo, 1 = entering second repo
 	spinner       spinner.Model
 	dashboard     DashboardModel
 	tree          TreeModel
@@ -40,6 +45,7 @@ type MainModel struct {
 	windowHeight  int
 	analysisType  string // quick, detailed, custom
 	appSettings    tea.LogOptionsSetter
+	compareResult *CompareResult // Holds comparison data
 }
 
 func NewMainModel() MainModel {
@@ -111,6 +117,12 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.menu.SelectedOption == 0 && m.menu.Done { // Analyze
 			m.state = stateInput
 			m.menu.Done = false // Reset for back navigation
+		} else if m.menu.SelectedOption == 1 && m.menu.Done { // Compare
+			m.state = stateCompareInput
+			m.compareStep = 0
+			m.compareInput1 = ""
+			m.compareInput2 = ""
+			m.menu.Done = false
 		} else if m.menu.SelectedOption == 2 && m.menu.Done { // Exit
 			return m, tea.Quit
 		}
@@ -140,20 +152,64 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyMsg:
 			switch msg.Type {
 			case tea.KeyEnter:
-				if m.input != "" {
-					m.state = stateLoading
-					cmds = append(cmds, m.analyzeRepo(m.input))
+				if m.compareStep == 0 && m.compareInput1 != "" {
+					// Move to second repo input
+					m.compareStep = 1
+				} else if m.compareStep == 1 && m.compareInput2 != "" {
+					// Both repos entered, start comparison
+					m.state = stateCompareLoading
+					cmds = append(cmds, m.compareRepos(m.compareInput1, m.compareInput2))
 				}
 			case tea.KeyBackspace:
-				if len(m.input) > 0 {
-					m.input = m.input[:len(m.input)-1]
+				if m.compareStep == 0 && len(m.compareInput1) > 0 {
+					m.compareInput1 = m.compareInput1[:len(m.compareInput1)-1]
+				} else if m.compareStep == 1 && len(m.compareInput2) > 0 {
+					m.compareInput2 = m.compareInput2[:len(m.compareInput2)-1]
 				}
 			case tea.KeyRunes:
-				m.input += string(msg.Runes)
+				if m.compareStep == 0 {
+					m.compareInput1 += string(msg.Runes)
+				} else {
+					m.compareInput2 += string(msg.Runes)
+				}
 			case tea.KeyEsc:
+				if m.compareStep == 1 {
+					// Go back to first repo input
+					m.compareStep = 0
+				} else {
+					m.state = stateMenu
+					m.menu.Done = false
+					m.compareInput1 = ""
+					m.compareInput2 = ""
+				}
+			}
+		}
+
+	case stateCompareLoading:
+		m.spinner, cmd = m.spinner.Update(msg)
+		cmds = append(cmds, cmd)
+
+		if result, ok := msg.(CompareResult); ok {
+			m.compareResult = &result
+			m.state = stateCompareResult
+			m.progress = nil
+		}
+		if err, ok := msg.(error); ok {
+			m.err = err
+			m.state = stateCompareInput
+			m.compareStep = 0
+			m.progress = nil
+		}
+
+	case stateCompareResult:
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			switch msg.String() {
+			case "q", "esc":
 				m.state = stateMenu
-				m.menu.Done = false
-				m.input = ""
+				m.compareResult = nil
+				m.compareInput1 = ""
+				m.compareInput2 = ""
 			}
 		}
 
@@ -193,6 +249,8 @@ func (m MainModel) View() string {
 		return m.menu.View()
 	case stateInput:
 		return m.inputView()
+	case stateCompareInput:
+		return m.compareInputView()
 	case stateLoading:
 		loadMsg := fmt.Sprintf("📊 Analyzing %s", m.input)
 		if m.analysisType != "" {
@@ -227,6 +285,18 @@ func (m MainModel) View() string {
 			lipgloss.Center, lipgloss.Center,
 			statusView,
 		)
+	case stateCompareLoading:
+		loadMsg := fmt.Sprintf("📊 Comparing %s vs %s", m.compareInput1, m.compareInput2)
+		statusView := fmt.Sprintf("%s %s...", m.spinner.View(), loadMsg)
+		statusView += "\n\n" + SubtleStyle.Render("Press ESC to cancel")
+
+		return lipgloss.Place(
+			m.windowWidth, m.windowHeight,
+			lipgloss.Center, lipgloss.Center,
+			statusView,
+		)
+	case stateCompareResult:
+		return m.compareResultView()
 	case stateDashboard:
 		return m.dashboard.View()
 	}
@@ -308,6 +378,179 @@ func (m MainModel) analyzeRepo(repoName string) tea.Cmd {
 			BusRisk:       busRisk,
 			MaturityScore: maturityScore,
 			MaturityLevel: maturityLevel,
+		}
+	}
+}
+
+func (m MainModel) compareInputView() string {
+	var currentInput string
+	var prompt string
+
+	if m.compareStep == 0 {
+		prompt = "📥 ENTER FIRST REPOSITORY"
+		currentInput = m.compareInput1
+	} else {
+		prompt = "📥 ENTER SECOND REPOSITORY"
+		currentInput = m.compareInput2
+	}
+
+	inputContent := TitleStyle.Render(prompt) + "\n\n"
+
+	if m.compareStep == 1 {
+		inputContent += SubtleStyle.Render("First: "+m.compareInput1) + "\n\n"
+	}
+
+	inputContent += InputStyle.Render("> "+currentInput) + "\n\n"
+	inputContent += SubtleStyle.Render("Format: owner/repo  •  Press Enter to continue  •  ESC to go back")
+
+	if m.err != nil {
+		inputContent += "\n\n" + ErrorStyle.Render(fmt.Sprintf("Error: %v", m.err))
+	}
+
+	box := BoxStyle.Render(inputContent)
+
+	if m.windowWidth == 0 {
+		return box
+	}
+
+	return lipgloss.Place(
+		m.windowWidth,
+		m.windowHeight,
+		lipgloss.Center,
+		lipgloss.Center,
+		box,
+	)
+}
+
+func (m MainModel) compareResultView() string {
+	if m.compareResult == nil || m.compareResult.Repo1.Repo == nil || m.compareResult.Repo2.Repo == nil {
+		return "No comparison data"
+	}
+
+	r1 := m.compareResult.Repo1
+	r2 := m.compareResult.Repo2
+
+	header := TitleStyle.Render(fmt.Sprintf("📊 Comparison: %s vs %s", r1.Repo.FullName, r2.Repo.FullName))
+
+	// Build comparison table
+	rows := []string{
+		fmt.Sprintf("%-20s │ %-25s │ %-25s", "Metric", r1.Repo.FullName, r2.Repo.FullName),
+		strings.Repeat("─", 75),
+		fmt.Sprintf("%-20s │ %-25d │ %-25d", "⭐ Stars", r1.Repo.Stars, r2.Repo.Stars),
+		fmt.Sprintf("%-20s │ %-25d │ %-25d", "🍴 Forks", r1.Repo.Forks, r2.Repo.Forks),
+		fmt.Sprintf("%-20s │ %-25d │ %-25d", "📦 Commits (1y)", len(r1.Commits), len(r2.Commits)),
+		fmt.Sprintf("%-20s │ %-25d │ %-25d", "👥 Contributors", len(r1.Contributors), len(r2.Contributors)),
+		fmt.Sprintf("%-20s │ %-25s │ %-25s", "💚 Health Score", fmt.Sprintf("%d", r1.HealthScore), fmt.Sprintf("%d", r2.HealthScore)),
+		fmt.Sprintf("%-20s │ %-25s │ %-25s", "⚠️ Bus Factor", fmt.Sprintf("%d (%s)", r1.BusFactor, r1.BusRisk), fmt.Sprintf("%d (%s)", r2.BusFactor, r2.BusRisk)),
+		fmt.Sprintf("%-20s │ %-25s │ %-25s", "🏗️ Maturity", fmt.Sprintf("%s (%d)", r1.MaturityLevel, r1.MaturityScore), fmt.Sprintf("%s (%d)", r2.MaturityLevel, r2.MaturityScore)),
+	}
+
+	tableContent := strings.Join(rows, "\n")
+	tableBox := BoxStyle.Render(tableContent)
+
+	// Verdict
+	var verdict string
+	if r1.MaturityScore > r2.MaturityScore {
+		verdict = fmt.Sprintf("➡️ %s appears more mature and stable.", r1.Repo.FullName)
+	} else if r2.MaturityScore > r1.MaturityScore {
+		verdict = fmt.Sprintf("➡️ %s appears more mature and stable.", r2.Repo.FullName)
+	} else {
+		verdict = "➡️ Both repositories are similarly mature."
+	}
+	verdictBox := BoxStyle.Render("📌 Verdict\n" + verdict)
+
+	footer := SubtleStyle.Render("q/ESC: back to menu")
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		header,
+		tableBox,
+		verdictBox,
+		footer,
+	)
+
+	if m.windowWidth == 0 {
+		return content
+	}
+
+	return lipgloss.Place(
+		m.windowWidth,
+		m.windowHeight,
+		lipgloss.Center,
+		lipgloss.Center,
+		content,
+	)
+}
+
+func (m MainModel) compareRepos(repo1Name, repo2Name string) tea.Cmd {
+	return func() tea.Msg {
+		parts1 := strings.Split(repo1Name, "/")
+		parts2 := strings.Split(repo2Name, "/")
+
+		if len(parts1) != 2 {
+			return fmt.Errorf("first repository must be in owner/repo format")
+		}
+		if len(parts2) != 2 {
+			return fmt.Errorf("second repository must be in owner/repo format")
+		}
+
+		client := github.NewClient()
+
+		// Analyze first repo
+		repo1, err := client.GetRepo(parts1[0], parts1[1])
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", repo1Name, err)
+		}
+		commits1, _ := client.GetCommits(parts1[0], parts1[1], 365)
+		contributors1, _ := client.GetContributors(parts1[0], parts1[1])
+		languages1, _ := client.GetLanguages(parts1[0], parts1[1])
+		fileTree1, _ := client.GetFileTree(parts1[0], parts1[1], repo1.DefaultBranch)
+		score1 := analyzer.CalculateHealth(repo1, commits1)
+		busFactor1, busRisk1 := analyzer.BusFactor(contributors1)
+		maturityScore1, maturityLevel1 := analyzer.RepoMaturityScore(repo1, len(commits1), len(contributors1), false)
+
+		result1 := AnalysisResult{
+			Repo:          repo1,
+			Commits:       commits1,
+			Contributors:  contributors1,
+			FileTree:      fileTree1,
+			Languages:     languages1,
+			HealthScore:   score1,
+			BusFactor:     busFactor1,
+			BusRisk:       busRisk1,
+			MaturityScore: maturityScore1,
+			MaturityLevel: maturityLevel1,
+		}
+
+		// Analyze second repo
+		repo2, err := client.GetRepo(parts2[0], parts2[1])
+		if err != nil {
+			return fmt.Errorf("failed to fetch %s: %w", repo2Name, err)
+		}
+		commits2, _ := client.GetCommits(parts2[0], parts2[1], 365)
+		contributors2, _ := client.GetContributors(parts2[0], parts2[1])
+		languages2, _ := client.GetLanguages(parts2[0], parts2[1])
+		fileTree2, _ := client.GetFileTree(parts2[0], parts2[1], repo2.DefaultBranch)
+		score2 := analyzer.CalculateHealth(repo2, commits2)
+		busFactor2, busRisk2 := analyzer.BusFactor(contributors2)
+		maturityScore2, maturityLevel2 := analyzer.RepoMaturityScore(repo2, len(commits2), len(contributors2), false)
+
+		result2 := AnalysisResult{
+			Repo:          repo2,
+			Commits:       commits2,
+			Contributors:  contributors2,
+			FileTree:      fileTree2,
+			Languages:     languages2,
+			HealthScore:   score2,
+			BusFactor:     busFactor2,
+			BusRisk:       busRisk2,
+			MaturityScore: maturityScore2,
+			MaturityLevel: maturityLevel2,
+		}
+
+		return CompareResult{
+			Repo1: result1,
+			Repo2: result2,
 		}
 	}
 }

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -14,3 +14,9 @@ type AnalysisResult struct {
 	MaturityScore int
 	MaturityLevel string
 }
+
+// CompareResult holds analysis data for two repositories
+type CompareResult struct {
+	Repo1 AnalysisResult
+	Repo2 AnalysisResult
+}


### PR DESCRIPTION
fixes #18 

## Summary
Fixes the "Compare Two Repositories" menu option which was completely non-functional.

## Problem
When selecting "Compare repositories" from the menu, the application would either:
- Do nothing
- Fall back to single-repository analysis
- Get stuck on input without transitioning to results

**Root cause:** Menu option 1 (Compare) was never handled in the `Update` function - only options 0 (Analyze) and 2 (Exit) were processed.

## Solution
- Added handler for menu option 1 to transition to `stateCompareInput`
- Added new states: `stateCompareLoading` and `stateCompareResult`
- Added `CompareResult` type to hold analysis data for two repos
- Implemented two-step input flow for collecting both repository names
- Added `compareInputView()` with sequential repo input and ESC to go back
- Added `compareResultView()` with side-by-side metrics table
- Added `compareRepos()` function to fetch and analyze both repositories

## Comparison View Shows
- Stars, Forks
- Commits (1 year), Contributors
- Health Score, Bus Factor
- Maturity Score with verdict

## Files Changed
- `internal/ui/app.go` - Main logic for compare flow
- `internal/ui/types.go` - Added `CompareResult` struct
