### PR TITLE
fix: export to Downloads folder and fix repo data display

### DIFF
--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -1,32 +1,29 @@
-package github
+﻿package github
 
 import "time"
 
 type Repo struct {
-	Name              string    `json:"name"`
-	FullName          string    `json:"full_name"`
-	Stars             int       `json:"stargazers_count"`
-	StargazersCount   int       `json:"stargazers_count"`
-	Forks             int       `json:"forks_count"`
-	ForksCount        int       `json:"forks_count"`
-	OpenIssues        int       `json:"open_issues_count"`
-	OpenIssuesCount   int       `json:"open_issues_count"`
-	Description       string    `json:"description"`
-	CreatedAt         time.Time `json:"created_at"`
-	UpdatedAt         time.Time `json:"updated_at"`
-	PushedAt          time.Time `json:"pushed_at"`
-	WatchersCount     int       `json:"watchers_count"`
-	Language          string    `json:"language"`
-	Fork              bool      `json:"fork"`
-	Archived          bool      `json:"archived"`
-	Private           bool      `json:"private"`
-	DefaultBranch     string    `json:"default_branch"`
-	HTMLURL           string    `json:"html_url"`
-	CloneURL          string    `json:"clone_url"`
+Name          string    `json:"name"`
+FullName      string    `json:"full_name"`
+Stars         int       `json:"stargazers_count"`
+Forks         int       `json:"forks_count"`
+OpenIssues    int       `json:"open_issues_count"`
+Description   string    `json:"description"`
+CreatedAt     time.Time `json:"created_at"`
+UpdatedAt     time.Time `json:"updated_at"`
+PushedAt      time.Time `json:"pushed_at"`
+WatchersCount int       `json:"watchers_count"`
+Language      string    `json:"language"`
+Fork          bool      `json:"fork"`
+Archived      bool      `json:"archived"`
+Private       bool      `json:"private"`
+DefaultBranch string    `json:"default_branch"`
+HTMLURL       string    `json:"html_url"`
+CloneURL      string    `json:"clone_url"`
 }
 
 func (c *Client) GetRepo(owner, repo string) (*Repo, error) {
-	var r Repo
-	err := c.get("https://api.github.com/repos/"+owner+"/"+repo, &r)
-	return &r, err
+var r Repo
+err := c.get("https://api.github.com/repos/"+owner+"/"+repo, &r)
+return &r, err
 }


### PR DESCRIPTION
## Summary
This PR fixes the export functionality and repo data display issues.

## Changes
- **Fix Repo struct** - Removed duplicate JSON field mappings that caused stars, forks, and issues to always show as 0
- **Export to Downloads folder** - All exports (JSON/Markdown) now save to system Downloads folder instead of local exports/ folder
- **Auto-open file manager** - After export, automatically opens file manager to show the exported file:
  - Windows: Uses \explorer /select,\ to highlight the file
  - macOS: Uses \open -R\ to reveal in Finder
  - Linux: Uses \xdg-open\ on the directory
- **Fix comparison export** - Fixed typos in comparison markdown export table

## Testing
- Verified repo data (stars, forks, issues) displays correctly in Repo view and Recruiter view
- Verified exports save to Downloads folder
- Verified file manager opens after export

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Exported files now save directly to your Downloads folder instead of a system-defined location, making them easier to locate and manage.
  * After exporting, files automatically open in your system's default file manager for immediate access.
  * Export functionality now features enhanced cross-platform support for Windows, macOS, and Linux.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->