### PR TITLE
Improve repository input UX, add history shortcut, and enhance documentation

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -263,14 +263,6 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case tea.KeyRunes:
 				r := string(msg.Runes)
-
-				// Shortcut: open history
-				if r == "h" || r == "H" {
-					m.state = stateHistory
-					m.historyCursor = 0
-					return m, nil
-				}
-
 				// Normal typing
 				m.input += r
 
@@ -282,7 +274,11 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Move to start - for TUI we just clear (no cursor)
 				// In a real implementation, you'd track cursor position
 			case tea.KeyCtrlE:
-				// Move to end - already at end in this simple impl
+			// Move to end - already at end in this simple impl
+			case tea.KeyCtrlH:
+				m.state = stateHistory
+				m.historyCursor = 0
+
 			case tea.KeyCtrlW:
 				// Delete word backward
 				m.input = strings.TrimRight(m.input, " ")
@@ -597,7 +593,7 @@ func (m MainModel) inputView() string {
 	inputContent :=
 		TitleStyle.Render("📥 ENTER REPOSITORY") + "\n\n" +
 			InputStyle.Render("> "+m.input) + "\n\n" +
-			SubtleStyle.Render("Format: owner/repo  •  Enter: run  •  ↑/↓: history  •  H: full history")
+			SubtleStyle.Render("Format: owner/repo  •  Enter: run  •  ↑/↓: history  •  Ctrl+H : full history")
 
 	if m.err != nil {
 		inputContent += "\n\n" + ErrorStyle.Render(fmt.Sprintf("Error: %v", m.err))

--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ After analysis, choose the export option from the menu to save results.
 | `Enter` | Confirm input / run analysis |
 | `ESC` | Go back / cancel current action |
 | `q` | Quit application (from main menu) |
-| `H` | Open analysis history |
+| `Ctrl + H` | Open analysis history |
 | `↑ / ↓` | Navigate menu or history |
 | `j / k` | Navigate lists (vim-style) |
 | `m` | Export comparison as Markdown |


### PR DESCRIPTION
This PR improves both user experience and usability of Repo-lyzer, along with documentation enhancements.

## ✨ Changes Made
---

### 🐛 Fixes
- Sanitized repository input to prevent invalid GitHub API URLs
- Handles pasted GitHub URLs and hidden/control characters gracefully
---

### 🚀 New UX Feature
- Added **`H` keyboard shortcut** in the repository input screen
- Allows users to quickly open **Analysis History** without retyping repo names
- Reuses existing history logic — no new APIs required
---

### 📚 Documentation Improvements
- Added keyboard shortcuts section
- Improved troubleshooting guidance
- Clarified correct repository input format
---

## 💡 Why this matters
- Faster workflow for repeat users
- Prevents common runtime errors
- Makes Repo-lyzer feel like a professional, power-user CLI
---
###  Contribution
Since this PR includes a bug fix, a usability feature, and documentation updates,
I kindly wanted to ask if this could be considered for **ECWoC Level 2 **.
---
Closes #43


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigate previous inputs with Up/Down while typing and apply selections into the input field
  * Open full history view from input (Ctrl+H / h) with its own navigation, re-analyze, delete, and clear actions
  * Improved in-app Help, Settings, and comparison workflows; UI now preserves per-session state and window sizing

* **Documentation**
  * Added Keyboard Shortcuts reference and Troubleshooting section
  * Reformatted Installation and usage presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->