### PR TITLE
Add analysis time display #131

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/agnivo988/Repo-lyzer/internal/analyzer"
 	"github.com/agnivo988/Repo-lyzer/internal/github"
@@ -148,6 +149,9 @@ var analyzeCmd = &cobra.Command{
 			return fmt.Errorf("invalid repository URL: %w", err)
 		}
 
+		// Record start time for analysis timing
+		startTime := time.Now()
+
 		// Initialize GitHub client
 		client := github.NewClient()
 
@@ -234,6 +238,10 @@ var analyzeCmd = &cobra.Command{
 		output.PrintHealth(score)
 		output.PrintGitHubAPIStatus(client)
 		output.PrintRecruiterSummary(summary)
+
+		// Display analysis time
+		duration := time.Since(startTime)
+		fmt.Printf("\n⏱️  Analysis completed in %.2f seconds\n", duration.Seconds())
 
 		return nil
 	},


### PR DESCRIPTION
## Description
This PR implements the feature request to display analysis time at the end of each repository analysis run, addressing issue #131.

## Problem
Users currently have no visibility into how long repository analysis takes, making it difficult to:

Estimate completion time for large repositories
Track performance metrics
Understand analysis duration for planning purposes
## Solution
Added timing functionality to the analyze command that:

Records the start time before analysis begins
Calculates total duration after all analysis completes
Displays the time in a user-friendly format
## Changes Made
File: [analyze.go](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Import: Added [time](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) package
Logic: Added start time recording and duration calculation
Output: Added timing display with stopwatch emoji and seconds precision
Output Format
Testing
✅ Code compiles successfully
✅ Existing tests pass
✅ Dry run functionality unaffected
✅ Timing displays correctly in analysis flow


This description provides context, explains the implementation, and follows good PR practices by referencing the issue number and including testing information. You can copy this directly into your GitHub PR description field.



Closes #131 