### PR TITLE
Add GitHub Action to auto-update contributors in README

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,35 @@
+name: Update Contributors in README
+
+on:
+  schedule:
+    - cron: "0 0 * * *"   # runs daily
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate contributors list
+        run: node scripts/generate_contributors.js
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git diff --cached --quiet || git commit -m "chore: update contributors list"
+
+      - name: Push changes
+        run: git push


### PR DESCRIPTION
Fixes #157

### What I did
- Added a GitHub Action workflow to automatically update the contributors section in `README.md`
- Uses GitHub API via `scripts/generate_contributors.js`
- Keeps the contributors list always up-to-date with avatars

### Note
This workflow may not run on fork PRs due to GitHub token permissions, but it will work after merging into the main repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to update the contributors list in the README daily and on manual trigger.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->