### PR TITLE
Implemented comp json output

### DIFF
--- a/internal/output/compact.go
+++ b/internal/output/compact.go
@@ -1,0 +1,145 @@
+package output
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/agnivo988/Repo-lyzer/internal/github"
+)
+
+// CompactConfig holds the measurements used to build the compact JSON export.
+type CompactConfig struct {
+	Repo            *github.Repo
+	HealthScore     int
+	BusFactor       int
+	BusRisk         string
+	MaturityScore   int
+	MaturityLevel   string
+	CommitsLastYear int
+	Contributors    int
+	Duration        time.Duration
+	Languages       map[string]int
+}
+
+// PrintCompactJSON writes the compact analysis summary to stdout.
+func PrintCompactJSON(cfg CompactConfig) error {
+	if cfg.Repo == nil {
+		cfg.Repo = &github.Repo{}
+	}
+
+	topLangs := buildTopLanguages(cfg.Languages, 3)
+	primaryLanguage := cfg.Repo.Language
+	if primaryLanguage == "" && len(topLangs) > 0 {
+		primaryLanguage = topLangs[0].Name
+	}
+
+	summary := compactAnalysis{
+		Repository: compactRepository{
+			FullName:        cfg.Repo.FullName,
+			Description:     cfg.Repo.Description,
+			URL:             cfg.Repo.HTMLURL,
+			PrimaryLanguage: primaryLanguage,
+			Stars:           cfg.Repo.Stars,
+			Forks:           cfg.Repo.Forks,
+			OpenIssues:      cfg.Repo.OpenIssues,
+		},
+		Metrics: compactMetrics{
+			HealthScore:     cfg.HealthScore,
+			BusFactor:       cfg.BusFactor,
+			BusRisk:         cfg.BusRisk,
+			MaturityScore:   cfg.MaturityScore,
+			MaturityLevel:   cfg.MaturityLevel,
+			CommitsLastYear: cfg.CommitsLastYear,
+			Contributors:    cfg.Contributors,
+		},
+		Metadata: compactMetadata{
+			DurationSeconds: cfg.Duration.Seconds(),
+			TopLanguages:    topLangs,
+		},
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(summary)
+}
+
+type compactAnalysis struct {
+	Repository compactRepository `json:"repository"`
+	Metrics    compactMetrics    `json:"metrics"`
+	Metadata   compactMetadata   `json:"metadata"`
+}
+
+type compactRepository struct {
+	FullName        string `json:"full_name"`
+	Description     string `json:"description,omitempty"`
+	URL             string `json:"url"`
+	PrimaryLanguage string `json:"primary_language,omitempty"`
+	Stars           int    `json:"stars"`
+	Forks           int    `json:"forks"`
+	OpenIssues      int    `json:"open_issues"`
+}
+
+type compactMetrics struct {
+	HealthScore     int    `json:"health_score"`
+	BusFactor       int    `json:"bus_factor"`
+	BusRisk         string `json:"bus_risk"`
+	MaturityScore   int    `json:"maturity_score"`
+	MaturityLevel   string `json:"maturity_level"`
+	CommitsLastYear int    `json:"commit_count_1y"`
+	Contributors    int    `json:"contributors"`
+}
+
+type compactMetadata struct {
+	DurationSeconds float64           `json:"analysis_duration_seconds"`
+	TopLanguages    []compactLanguage `json:"top_languages,omitempty"`
+}
+
+type compactLanguage struct {
+	Name       string  `json:"name"`
+	Percentage float64 `json:"percentage"`
+}
+
+func buildTopLanguages(langs map[string]int, limit int) []compactLanguage {
+	if limit <= 0 || len(langs) == 0 {
+		return nil
+	}
+
+	type langEntry struct {
+		name string
+		size int
+	}
+
+	entries := make([]langEntry, 0, len(langs))
+	total := 0
+	for name, size := range langs {
+		if size <= 0 {
+			continue
+		}
+		total += size
+		entries = append(entries, langEntry{name: name, size: size})
+	}
+
+	if total == 0 || len(entries) == 0 {
+		return nil
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].size > entries[j].size
+	})
+
+	if limit > len(entries) {
+		limit = len(entries)
+	}
+
+	top := make([]compactLanguage, 0, limit)
+	for i := 0; i < limit; i++ {
+		entry := entries[i]
+		percentage := float64(entry.size) / float64(total) * 100
+		top = append(top, compactLanguage{Name: entry.name, Percentage: percentage})
+	}
+
+	return top
+}


### PR DESCRIPTION
CLI change: [analyze.go:139-272](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now reads the new flag, exits early with [output.PrintCompactJSON](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when requested, and reuses the previously captured duration for both the compact JSON metadata and the regular human-facing footer.
Compact exporter: [compact.go:1-145](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) introduces CompactConfig plus [PrintCompactJSON](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which encodes the repository, metrics, and top languages into a compact JSON object with indentation for readability.
Testing: go test [Downloads](http://_vscodecontentref_/6). (fails because the repository already needs go mod tidy; command aborted before exercising the new logic)
Closes #168 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--compact` flag to the analyze command for streamlined, machine-friendly JSON output
  * Compact mode outputs a structured JSON summary containing repository metadata, health metrics, and analysis duration
  * Optimized performance in compact mode by reducing unnecessary computations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->