### PR TITLE
Fix Quality dashboard hiding top navigation tabs

### DIFF
--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -290,8 +290,8 @@ func (m DashboardModel) View() string {
 	return lipgloss.Place(
 		m.width,
 		m.height,
-		lipgloss.Center,
-		lipgloss.Center,
+		lipgloss.Left,
+		lipgloss.Top,
 		fullContent,
 	)
 }
@@ -839,13 +839,22 @@ func (m DashboardModel) qualityDashboardView() string {
 		"\n"+recsContent,
 	))
 
+	bottomPanels := lipgloss.JoinHorizontal(lipgloss.Top, hotspotsBox, " ", recsBox)
+	if m.width > 0 {
+		combinedWidth := lipgloss.Width(hotspotsBox) + 1 + lipgloss.Width(recsBox)
+		// Fall back to vertical stacking on narrower terminals.
+		if combinedWidth > m.width {
+			bottomPanels = lipgloss.JoinVertical(lipgloss.Left, hotspotsBox, "\n", recsBox)
+		}
+	}
+
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
 		header,
 		"\n",
 		summaryBox,
 		"\n",
-		lipgloss.JoinHorizontal(lipgloss.Top, hotspotsBox, " ", recsBox),
+		bottomPanels,
 	)
 }
 

--- a/internal/ui/dashboard_regression_test.go
+++ b/internal/ui/dashboard_regression_test.go
@@ -1,0 +1,63 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agnivo988/Repo-lyzer/internal/analyzer"
+	"github.com/agnivo988/Repo-lyzer/internal/github"
+)
+
+func TestDashboardQualityView_KeepsTopTabsVisibleWhenContentOverflows(t *testing.T) {
+	model := NewDashboardModel()
+	model.currentView = viewQualityDashboard
+	model.width = 80
+	model.height = 12
+
+	repo := &github.Repo{
+		FullName:      "owner/repo",
+		Description:   "Regression test repository",
+		DefaultBranch: "main",
+		HTMLURL:       "https://github.com/owner/repo",
+		CreatedAt:     time.Now(),
+		PushedAt:      time.Now(),
+	}
+
+	model.SetData(AnalysisResult{
+		Repo: repo,
+		QualityDashboard: &analyzer.QualityDashboard{
+			OverallScore: 69,
+			RiskLevel:    "Medium",
+			QualityGrade: "C",
+			KeyMetrics: analyzer.DashboardMetrics{
+				HealthScore:      90,
+				SecurityScore:    100,
+				MaturityLevel:    "Prototype",
+				BusFactor:        2,
+				ActivityLevel:    "Low",
+				ContributorCount: 17,
+			},
+			ProblemHotspots: []analyzer.ProblemHotspot{
+				{Area: "Bus Factor", Severity: "High", Description: "Very low contributor diversity"},
+				{Area: "Security", Severity: "Medium", Description: "Security checks need hardening"},
+				{Area: "Activity", Severity: "Medium", Description: "Low activity in the last 90 days"},
+				{Area: "Testing", Severity: "Low", Description: "Missing coverage on critical paths"},
+				{Area: "Docs", Severity: "Low", Description: "Insufficient onboarding docs"},
+			},
+			Recommendations: []string{
+				"👥 Encourage more contributors to reduce bus factor risk",
+				"📚 Improve documentation to enable easier onboarding",
+				"🧪 Add regression coverage for UI layout behavior",
+				"🔒 Improve security checks in CI",
+				"📈 Increase regular maintenance cadence",
+			},
+		},
+	})
+
+	view := model.View()
+
+	if !strings.Contains(view, "Overview") || !strings.Contains(view, "Quality") {
+		t.Fatalf("top tabs not visible in quality view output:\n%s", view)
+	}
+}


### PR DESCRIPTION
fixes #162 
## Summary
- fix dashboard layout placement so the top tab bar remains visible under content overflow
- make Quality dashboard responsive by stacking hotspots/recommendations vertically on narrow terminals
- add regression test to ensure `Overview`/`Quality` tabs remain visible in constrained terminal sizes

## Problem
In the `Quality` view, the top navigation tabs could disappear when rendering larger content, making tab navigation unclear.

## Root cause
The full dashboard block was centered vertically/horizontally. When the content exceeded terminal bounds, the top area (including tabs) could be clipped.

## Changes
- Updated `DashboardModel.View()` to anchor dashboard content to top-left placement.
- Updated `qualityDashboardView()` to switch bottom cards to vertical layout when combined width exceeds terminal width.
- Added `TestDashboardQualityView_KeepsTopTabsVisibleWhenContentOverflows` in `internal/ui/dashboard_regression_test.go`.

## Validation
- lint check on updated/new UI files passed
- regression test added for issue #162 scenario



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard layout positioning and responsiveness to ensure content remains visible when space is constrained.
  * Dashboard now intelligently adapts layout orientation based on available terminal dimensions.

* **Tests**
  * Added regression test to verify dashboard tabs remain visible during content overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->