### PR TITLE
Add: automated cross-platform binary release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release Binaries
+
+# Triggers ONLY on version tags (e.g. v1.0.7), never on branch pushes.
+"on":
+  push:
+    tags:
+      - 'v*'
+
+# Required for creating/uploading GitHub Releases and their assets.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build & Release (${{ matrix.suffix }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Keep going with other platforms even if one fails.
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            suffix: linux-amd64
+          - goos: linux
+            goarch: arm64
+            suffix: linux-arm64
+          - goos: darwin
+            goarch: amd64
+            suffix: macos-amd64
+          - goos: darwin
+            goarch: arm64
+            suffix: macos-arm64
+          - goos: windows
+            goarch: amd64
+            suffix: windows-amd64.exe
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Keep in sync with the go directive in go.mod.
+          go-version: '1.24'
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          go build \
+            -ldflags="-s -w -X github.com/agnivo988/Repo-lyzer/cmd.version=${{ github.ref_name }}" \
+            -o repo-lyzer-${{ matrix.suffix }} \
+            .
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: repo-lyzer-${{ matrix.suffix }}
+          # Auto-generate changelog from commit messages since the last tag.
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// version is the current release version.
+// It defaults to "dev" for local builds and is overridden at release time via:
+//
+//	go build -ldflags="-X github.com/agnivo988/Repo-lyzer/cmd.version=v1.0.7"
+var version = "dev"
+
 var rootCmd = &cobra.Command{
 	Use:   "repo-lyzer",
 	Short: "Analyze GitHub repositories from the terminal",
@@ -54,7 +60,7 @@ Examples:
   repo-lyzer cache list
 
 Documentation: https://github.com/agnivo988/Repo-lyzer`,
-	Version: "v1.0.0",
+	Version: version,
 }
 
 // Execute is used for cobra commands


### PR DESCRIPTION
Closes #264

Adds `.github/workflows/release.yml` — a GitHub Actions workflow that automatically builds and publishes pre-built binaries for all 5 platforms whenever a `v*` tag is pushed.

Also updates `cmd/root.go` to support version injection via `-ldflags` so `--version` prints the correct release tag in built binaries.

## Why it's needed

Currently installing Repo-lyzer requires Go to be installed locally. This is a barrier for non-Go users. With this change, anyone can download and run Repo-lyzer with a single `curl` command — no Go toolchain needed.

## Files changed

| File | Change |
|---|---|
| `.github/workflows/release.yml` | New — automated release workflow |
| `cmd/root.go` | Modified — added `version` var for ldflags injection |

## Platforms supported

| Binary | Platform |
|---|---|
| `repo-lyzer-linux-amd64` | Linux x86_64 |
| `repo-lyzer-linux-arm64` | Linux ARM64 / Raspberry Pi |
| `repo-lyzer-macos-amd64` | macOS Intel |
| `repo-lyzer-macos-arm64` | macOS Apple Silicon M1/M2/M3 |
| `repo-lyzer-windows-amd64.exe` | Windows x86_64 |

## Testing

- YAML validated with [actionlint](https://rhysd.github.io/actionlint/) — no errors
- Build command tested locally on macOS ARM64, binary confirmed working:

```bash
./repo-lyzer-macos-arm64 --version
# repo-lyzer version v1.0.7
```

## Notes

- `go-version` set to `1.24` to match `go.mod` (issue template suggested `1.22` which would be a downgrade)
- `CGO_ENABLED=0` added for clean cross-compilation from a single Linux runner
- `fail-fast: false` so one platform failure doesn't cancel the other 4 builds
- ldflags path corrected to `-X github.com/agnivo988/Repo-lyzer/cmd.version` (issue template used `-X main.version` which has no effect as there is no `version` var in `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set up automated release binary publishing to GitHub Releases for multiple platforms (Linux, macOS, Windows)
  * Implemented proper version tracking for release builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->