### PR TITLE
fix: swallowed commit errors and misleading "Commits (1y)" label in compare.go

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -39,7 +39,7 @@ Comparison includes:
   • Stars, Forks, and Open Issues
   • Commit activity (past year)
   • Contributor count and engagement
-  • Bus Factor and risk assessment  
+  • Bus Factor and risk assessment
   • Repository maturity scores
   • Verdict on which repository is more mature/stable
 
@@ -68,53 +68,117 @@ Examples:
 		// Create progress spinner
 		spinner := progress.NewSpinner()
 
-		// Fetch first repository
+		// ---------- Fetch Repo 1 ----------
 		spinner.Start(fmt.Sprintf("🔍 Analyzing %s/%s...", r1[0], r1[1]))
+
 		repo1, err := client.GetRepo(r1[0], r1[1])
 		if err != nil {
 			spinner.Stop()
 			return err
 		}
 
+		// Optional metrics
 		_, _ = client.GetLanguages(r1[0], r1[1])
-		commits1, _ := client.GetCommits(r1[0], r1[1], 14)
-		contributors1, err := client.GetContributorsWithAvatars(r1[0], r1[1], 15)
+
+		// Required metrics
+		commits1, err := client.GetCommits(r1[0], r1[1], 365)
 		if err != nil {
 			spinner.Stop()
-			fmt.Printf("Error fetching contributors for %s/%s: %v\n", r1[0], r1[1], err)
-			return err
+			return fmt.Errorf(
+				"failed to get commits for %s/%s: %w",
+				r1[0],
+				r1[1],
+				err,
+			)
 		}
+
+		contributors1, err := client.GetContributorsWithAvatars(
+			r1[0],
+			r1[1],
+			15,
+		)
+		if err != nil {
+			spinner.Stop()
+			return fmt.Errorf(
+				"failed to get contributors for %s/%s: %w",
+				r1[0],
+				r1[1],
+				err,
+			)
+		}
+
+		// Optional tree data
 		_, _ = client.GetFileTree(r1[0], r1[1], repo1.DefaultBranch)
+
 		bus1, risk1 := analyzer.BusFactor(contributors1)
 
 		maturityScore1, maturityLevel1 :=
-			analyzer.RepoMaturityScore(repo1, len(commits1), len(contributors1), false)
+			analyzer.RepoMaturityScore(
+				repo1,
+				len(commits1),
+				len(contributors1),
+				false,
+			)
 
-		spinner.StopWithMessage(fmt.Sprintf("Analyzed %s/%s", r1[0], r1[1]))
+		spinner.StopWithMessage(
+			fmt.Sprintf("Analyzed %s/%s", r1[0], r1[1]),
+		)
 
 		// ---------- Fetch Repo 2 ----------
 		spinner.Start(fmt.Sprintf("🔍 Analyzing %s/%s...", r2[0], r2[1]))
+
 		repo2, err := client.GetRepo(r2[0], r2[1])
 		if err != nil {
 			spinner.Stop()
 			return err
 		}
 
+		// Optional metrics
 		_, _ = client.GetLanguages(r2[0], r2[1])
-		commits2, _ := client.GetCommits(r2[0], r2[1], 14)
-		contributors2, err := client.GetContributorsWithAvatars(r2[0], r2[1], 15)
+
+		// Required metrics
+		commits2, err := client.GetCommits(r2[0], r2[1], 365)
 		if err != nil {
 			spinner.Stop()
-			fmt.Printf("Error fetching contributors for %s/%s: %v\n", r2[0], r2[1], err)
-			return err
+			return fmt.Errorf(
+				"failed to get commits for %s/%s: %w",
+				r2[0],
+				r2[1],
+				err,
+			)
 		}
+
+		contributors2, err := client.GetContributorsWithAvatars(
+			r2[0],
+			r2[1],
+			15,
+		)
+		if err != nil {
+			spinner.Stop()
+			return fmt.Errorf(
+				"failed to get contributors for %s/%s: %w",
+				r2[0],
+				r2[1],
+				err,
+			)
+		}
+
+		// Optional tree data
 		_, _ = client.GetFileTree(r2[0], r2[1], repo2.DefaultBranch)
+
 		bus2, risk2 := analyzer.BusFactor(contributors2)
 
 		maturityScore2, maturityLevel2 :=
-			analyzer.RepoMaturityScore(repo2, len(commits2), len(contributors2), false)
+			analyzer.RepoMaturityScore(
+				repo2,
+				len(commits2),
+				len(contributors2),
+				false,
+			)
 
-		spinner.StopWithMessage(fmt.Sprintf("Analyzed %s/%s", r2[0], r2[1]))
+		spinner.StopWithMessage(
+			fmt.Sprintf("Analyzed %s/%s", r2[0], r2[1]),
+		)
 
 		// ---------- Output Table ----------
 		fmt.Println("\n📊 Repository Comparison")
@@ -122,32 +186,38 @@ Examples:
 		table := tablewriter.NewWriter(os.Stdout)
 		table.Header([]string{"Metric", repo1.FullName, repo2.FullName})
 
-		table.Append([]string{"⭐ Stars",
+		table.Append([]string{
+			"⭐ Stars",
 			fmt.Sprintf("%d", repo1.Stars),
 			fmt.Sprintf("%d", repo2.Stars),
 		})
 
-		table.Append([]string{"🍴 Forks",
+		table.Append([]string{
+			"🍴 Forks",
 			fmt.Sprintf("%d", repo1.Forks),
 			fmt.Sprintf("%d", repo2.Forks),
 		})
 
-		table.Append([]string{"📦 Commits (1y)",
+		table.Append([]string{
+			"📦 Commits (1y)",
 			fmt.Sprintf("%d", len(commits1)),
 			fmt.Sprintf("%d", len(commits2)),
 		})
 
-		table.Append([]string{"👥 Contributors",
+		table.Append([]string{
+			"👥 Contributors",
 			fmt.Sprintf("%d", len(contributors1)),
 			fmt.Sprintf("%d", len(contributors2)),
 		})
 
-		table.Append([]string{"⚠️ Bus Factor",
+		table.Append([]string{
+			"⚠️ Bus Factor",
 			fmt.Sprintf("%d (%s)", bus1, risk1),
 			fmt.Sprintf("%d (%s)", bus2, risk2),
 		})
 
-		table.Append([]string{"🏗️ Maturity",
+		table.Append([]string{
+			"🏗️ Maturity",
 			fmt.Sprintf("%s (%d)", maturityLevel1, maturityScore1),
 			fmt.Sprintf("%s (%d)", maturityLevel2, maturityScore2),
 		})
@@ -169,10 +239,17 @@ Examples:
 
 		// ---------- Verdict ----------
 		fmt.Println("\n Verdict")
+
 		if maturityScore1 > maturityScore2 {
-			fmt.Printf("➡️ %s appears more mature and stable.\n", repo1.FullName)
+			fmt.Printf(
+				"➡️ %s appears more mature and stable.\n",
+				repo1.FullName,
+			)
 		} else if maturityScore2 > maturityScore1 {
-			fmt.Printf("➡️ %s appears more mature and stable.\n", repo2.FullName)
+			fmt.Printf(
+				"➡️ %s appears more mature and stable.\n",
+				repo2.FullName,
+			)
 		} else {
 			fmt.Println("➡️ Both repositories are similarly mature.")
 		}
@@ -195,5 +272,6 @@ func countTreeStats(tree []github.TreeEntry) (files, dirs, totalSize int) {
 			dirs++
 		}
 	}
+
 	return
 }


### PR DESCRIPTION
## Summary

Fixes silent commit fetch failures in compare.go that could produce incorrect comparison metrics and misleading maturity scoring.

### Changes

- Handle GetCommits errors instead of silently ignoring them
- Stop spinner before returning commit fetch errors
- Align commit fetch window with displayed "Commits (1y)" label by using 365 days instead of 14

## Impact

Previously, failed commit fetches resulted in empty commit datasets being treated as valid data, producing incorrect comparison output without warning.

## Verification

- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended commit history analysis to cover a full 365-day window for more comprehensive metrics.
  * Updated compare command description to include "Bus Factor and risk assessment" assessment.

* **Bug Fixes**
  * Improved error handling with contextual error messages during repository metrics validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->