### PR TITLE
Implemented detailed flag in trends command

### DIFF
--- a/cmd/trends.go
+++ b/cmd/trends.go
@@ -135,7 +135,7 @@ func runTrends(repoArg string, cmd *cobra.Command) error {
 	if jsonFlag {
 		output.PrintTrendCompact(metrics)
 	} else {
-		output.PrintTrendMetrics(metrics)
+		output.PrintTrendMetrics(metrics, detailedFlag)
 
 		// Track analysis duration
 		duration := time.Since(startTime)

--- a/internal/output/trends.go
+++ b/internal/output/trends.go
@@ -98,7 +98,7 @@ func printCommitTrends(metrics *analyzer.TrendMetrics, detailed bool) {
     fmt.Println("Monthly Breakdown:")
     
     for _, month := range metrics.MonthlyData {
-        fmt.Printf("- %s : %d commits\n", month.Month.Format("Jan 6"), month.Commits)
+        fmt.Printf("- %s : %d commits\n", month.Month.Format("Jan 06"), month.Commits)
     }
 
     fmt.Println()

--- a/internal/output/trends.go
+++ b/internal/output/trends.go
@@ -36,7 +36,7 @@ var (
 )
 
 // PrintTrendMetrics prints comprehensive trend analysis results
-func PrintTrendMetrics(metrics *analyzer.TrendMetrics) {
+func PrintTrendMetrics(metrics *analyzer.TrendMetrics, detailedFlag bool) {
 	fmt.Println()
 	fmt.Println(strings.Repeat("=", 60))
 	fmt.Println(trendHeaderStyle.Render("📈 REPOSITORY TREND ANALYSIS"))
@@ -50,7 +50,7 @@ func PrintTrendMetrics(metrics *analyzer.TrendMetrics) {
 	printOverallTrend(metrics)
 
 	// Commit Trends
-	printCommitTrends(metrics)
+	printCommitTrends(metrics, detailedFlag)
 
 	// Contributor Trends
 	printContributorTrends(metrics)
@@ -83,7 +83,7 @@ func printOverallTrend(metrics *analyzer.TrendMetrics) {
 }
 
 // printCommitTrends prints commit frequency trends
-func printCommitTrends(metrics *analyzer.TrendMetrics) {
+func printCommitTrends(metrics *analyzer.TrendMetrics, detailed bool) {
 	fmt.Println("COMMIT TRENDS")
 	fmt.Println(strings.Repeat("-", 40))
 
@@ -94,6 +94,15 @@ func printCommitTrends(metrics *analyzer.TrendMetrics) {
 	fmt.Printf("   Change Rate: %.1f%%\n", metrics.CommitChangeRate)
 	fmt.Printf("   Avg/Month: %.1f commits\n", metrics.AvgCommitsPerMonth)
 	fmt.Printf("   Sparkline: %s\n\n", sparkline)
+	if detailed {
+    fmt.Println("Monthly Breakdown:")
+    
+    for _, month := range metrics.MonthlyData {
+        fmt.Printf("- %s : %d commits\n", month.Month, month.Commits)
+    }
+
+    fmt.Println()
+}
 }
 
 // printContributorTrends prints contributor growth trends

--- a/internal/output/trends.go
+++ b/internal/output/trends.go
@@ -98,7 +98,7 @@ func printCommitTrends(metrics *analyzer.TrendMetrics, detailed bool) {
     fmt.Println("Monthly Breakdown:")
     
     for _, month := range metrics.MonthlyData {
-        fmt.Printf("- %s : %d commits\n", month.Month, month.Commits)
+        fmt.Printf("- %s : %d commits\n", month.Month.Format("Jan 6"), month.Commits)
     }
 
     fmt.Println()


### PR DESCRIPTION
Implemented support for the `--detailed` flag in the trends command.

## Changes Made

* Passed `detailedFlag` into trend output functions
* Added detailed monthly breakdown display for commit trends
* Updated trend metrics output logic

## Result

Users can now use:

repo-lyzer trends owner/repo --detailed

to view monthly commit breakdown data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `--detailed` flag now correctly applies to trends output when not using JSON, so rendered results respect the flag.
  * When `--detailed` is enabled, the trends output includes an additional "Monthly Breakdown" with monthly trend data for deeper visibility into commit patterns and activity over time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->