### PR TITLE
#171 : Add support for saving analysis output as JSON file

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -538,6 +538,12 @@ func init() {
 		"Display a quick 5-line repository summary",
 	)
 
+	analyzeCmd.Flags().String(
+	"save",
+	"",
+	"Save full analysis JSON to a file",
+	)
+
 	analyzeCmd.Flags().Bool(
 		"incremental",
 		false,

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"encoding/json"
+	"os"
 	"fmt"
 	"strings"
 

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -30,3 +30,56 @@ func PrintLanguages(langs map[string]int) {
 		fmt.Printf("%-10s %s %.1f%%\n", lang, bar, percent)
 	}
 }
+
+type AnalysisOutput struct {
+	Repo           interface{}    `json:"Repo"`
+	Commits        interface{}    `json:"Commits"`
+	Contributors   interface{}    `json:"Contributors"`
+	FileTree       interface{}    `json:"FileTree"`
+	Languages      map[string]int `json:"Languages"`
+	HealthScore    int            `json:"HealthScore"`
+	BusFactor      int            `json:"BusFactor"`
+	BusRisk        string         `json:"BusRisk"`
+	MaturityScore  int            `json:"MaturityScore"`
+	MaturityLevel  string         `json:"MaturityLevel"`
+}
+
+func SaveAnalysisJSON(
+	path string,
+	repo interface{},
+	commits interface{},
+	contributors interface{},
+	fileTree interface{},
+	langs map[string]int,
+	healthScore int,
+	busFactor int,
+	busRisk string,
+	maturityScore int,
+	maturityLevel string,
+) error {
+
+	data := AnalysisOutput{
+		Repo:          repo,
+		Commits:       commits,
+		Contributors:  contributors,
+		FileTree:      fileTree,
+		Languages:     langs,
+		HealthScore:   healthScore,
+		BusFactor:     busFactor,
+		BusRisk:       busRisk,
+		MaturityScore: maturityScore,
+		MaturityLevel: maturityLevel,
+	}
+
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(path, jsonData, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

Added a `--save` option to the `analyze` command to allow saving the complete analysis output into a JSON file.

## Changes Made

- Added a new `--save` CLI flag in `cmd/analyze.go`
- Added support for exporting analysis results as formatted JSON
- Implemented file writing in `internal/output/json.go`
- Used `os.WriteFile` to create/overwrite the specified file
- Kept the existing stdout output behavior unchanged
- Added a confirmation message displaying the saved file path

This creates/overwrites `report.json` with the full analysis output while still showing the analysis in the terminal.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--save` flag to the analyze command, enabling users to export complete analysis results to a JSON file for archival and further processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->