### PR TITLE
fix: harden github API client against unhandled 403 forbidden responses

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -73,7 +73,7 @@ func (c *Client) get(url string, target interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	// Handle rate limiting with detailed message
+	// Handle rate limiting and forbidden states securely
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == 429 {
 		remaining := resp.Header.Get("X-RateLimit-Remaining")
 		resetTime := resp.Header.Get("X-RateLimit-Reset")
@@ -90,6 +90,9 @@ func (c *Client) get(url string, target interface{}) error {
 			}
 			return fmt.Errorf("🔴 Rate limit exceeded! Resets in %s", formatDuration(waitTime))
 		}
+		
+		// Fallback protective validation gate for other 403 scenarios
+		return fmt.Errorf("access forbidden (Status 403): the request was rejected by GitHub API or requires extended permissions")
 	}
 
 	if resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Fixes #308

## Proposed Changes
- **Hardened 403/Forbidden Boundary Protection:** Refactored the core GitHub API client fetch pipeline inside `internal/github/client.go`.
- **Prevented Silent Data Marshaling Failures:** Resolved a bug where non-rate-limit 403 Forbidden exceptions skipped explicit error catches, passing error string streams directly to the `json.NewDecoder` parser.
- **Graceful Error Recovery:** Appended a secondary fallback gate that outputs a explicit clean descriptive exit token string instead of letting the console throw an unhandled internal panic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messages to provide clearer feedback when access is denied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->