### PR TITLE
Fix/rust cargo parser

### DIFF
--- a/internal/analyzer/dependencies.go
+++ b/internal/analyzer/dependencies.go
@@ -427,6 +427,16 @@ func parseCargoToml(content []byte) ([]Dependency, string) {
 				name := strings.TrimSpace(parts[0])
 				version := strings.Trim(strings.TrimSpace(parts[1]), "\"'")
 
+				// Handle Rust inline table dependencies (e.g., serde = { version = "1.0", features = ["derive"] })
+				if strings.HasPrefix(version, "{") {
+					versionPattern := regexp.MustCompile(`version\s*=\s*["']([^"']+)["']`)
+					if matches := versionPattern.FindStringSubmatch(version); len(matches) >= 2 {
+						version = matches[1]
+					} else {
+						version = "*"
+					}
+				}
+
 				depType := "production"
 				if inDevDeps {
 					depType = "dev"

--- a/internal/analyzer/dependencies_test.go
+++ b/internal/analyzer/dependencies_test.go
@@ -57,3 +57,32 @@ func TestParseRequirementsTxt(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCargoToml(t *testing.T) {
+	content := `
+[dependencies]
+serde = "1.0"
+tokio = { version = "1.15", features = ["full"] }
+rand = { version = '0.8.5' }
+other-pkg = { path = "../other" }
+
+[dev-dependencies]
+tokio-test = "0.4"
+tempfile = { version = "3.3" }
+`
+
+	expected := []Dependency{
+		{Name: "serde", Version: "1.0", Type: "production"},
+		{Name: "tokio", Version: "1.15", Type: "production"},
+		{Name: "rand", Version: "0.8.5", Type: "production"},
+		{Name: "other-pkg", Version: "*", Type: "production"},
+		{Name: "tokio-test", Version: "0.4", Type: "dev"},
+		{Name: "tempfile", Version: "3.3", Type: "dev"},
+	}
+
+	got, _ := parseCargoToml([]byte(content))
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("parseCargoToml() =\n%v\nwant:\n%v", got, expected)
+	}
+}
+


### PR DESCRIPTION
### Description
This Pull Request resolves a bug in the Rust dependency parser where dependency versions defined via inline tables (e.g., `serde = { version = "1.0", features = ["derive"] }`) were parsed incorrectly. 

Previously, the parser would split on the `=` character and trim only quotes/whitespace, resulting in the entire inline table block `{ version = "1.0", features = ["derive"] }` being stored as the version. This caused downstream security scanning and vulnerability analysis lookups to fail.

Fixes #291

### Solution
- Updated `parseCargoToml` in `internal/analyzer/dependencies.go` to detect if the version value is an inline table (prefixed with `{`).
- Used a regular expression to extract the `version` field value specifically from the inline table, falling back to `"*"` if no version is defined.
- Added comprehensive unit test coverage in `internal/analyzer/dependencies_test.go` to verify standard string versions, inline tables, single quotes, double quotes, and path-only inline table definitions.

### Changes
* `internal/analyzer/dependencies.go`: Updated `parseCargoToml` with inline table version parsing regex logic.
* `internal/analyzer/dependencies_test.go`: Added `TestParseCargoToml` to verify parsing logic.

### Verification Results
Ran unit tests in the analyzer package:
```
go test ./internal/analyzer/...
```
Output:  ``` ok  github.com/agnivo988/Repo-lyzer/internal/analyzer  0.884s ```
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Rust dependency parsing to recognize and handle inline-table dependency declarations with version extraction, and automatic fallback to wildcard versioning when versions are unspecified.

* **Tests**
  * Added comprehensive test suite for Cargo.toml manifest file parsing, covering production and development dependencies with various version formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->