### PR TITLE
Fix/file viewer branch

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -688,7 +688,11 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.dashboard.data.Repo != nil && m.dashboard.data.Repo.FullName != "" {
 					repoName = m.dashboard.data.Repo.FullName
 				}
-				m.fileEdit = NewFileEditModel(m.tree.SelectedPath, repoName)
+				defaultBranch := "main"
+				if m.dashboard.data.Repo != nil && m.dashboard.data.Repo.DefaultBranch != "" {
+					defaultBranch = m.dashboard.data.Repo.DefaultBranch
+				}
+				m.fileEdit = NewFileEditModel(m.tree.SelectedPath, repoName, defaultBranch)
 
 				// Check ownership
 				isOwner := m.checkOwnership()

--- a/internal/ui/file_edit.go
+++ b/internal/ui/file_edit.go
@@ -16,19 +16,20 @@ import (
 )
 
 type FileEditModel struct {
-	filePath  string
-	repoOwner string
-	repoName  string
-	isOwner   bool
-	width     int
-	height    int
-	Done      bool
-	statusMsg string
-	clonePath string
-	isCloned  bool
+	filePath      string
+	repoOwner     string
+	repoName      string
+	defaultBranch string
+	isOwner       bool
+	width         int
+	height        int
+	Done          bool
+	statusMsg     string
+	clonePath     string
+	isCloned      bool
 }
 
-func NewFileEditModel(filePath, repoFullName string) FileEditModel {
+func NewFileEditModel(filePath, repoFullName, defaultBranch string) FileEditModel {
 	parts := strings.Split(repoFullName, "/")
 	repoOwner := ""
 	repoName := ""
@@ -45,12 +46,17 @@ func NewFileEditModel(filePath, repoFullName string) FileEditModel {
 		isCloned = true
 	}
 
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+
 	return FileEditModel{
-		filePath:  filePath,
-		repoOwner: repoOwner,
-		repoName:  repoName,
-		clonePath: clonePath,
-		isCloned:  isCloned,
+		filePath:      filePath,
+		repoOwner:     repoOwner,
+		repoName:      repoName,
+		defaultBranch: defaultBranch,
+		clonePath:     clonePath,
+		isCloned:      isCloned,
 	}
 }
 
@@ -175,7 +181,7 @@ func getDesktopPath() string {
 // openInBrowser opens the file on GitHub in the default browser
 func (m FileEditModel) openInBrowser() tea.Cmd {
 	return func() tea.Msg {
-		githubURL, err := buildBlobURL("github.com", m.repoOwner, m.repoName, m.filePath)
+		githubURL, err := buildBlobURL("github.com", m.repoOwner, m.repoName, m.defaultBranch, m.filePath)
 		if err != nil {
 			return openResultMsg{err}
 		}
@@ -189,7 +195,7 @@ func (m FileEditModel) openInBrowser() tea.Cmd {
 func (m FileEditModel) openInVSCode() tea.Cmd {
 	return func() tea.Msg {
 		// Use vscode.dev to open the file in browser-based VS Code
-		vscodeURL, err := buildVSCodeBlobURL(m.repoOwner, m.repoName, m.filePath)
+		vscodeURL, err := buildVSCodeBlobURL(m.repoOwner, m.repoName, m.defaultBranch, m.filePath)
 		if err != nil {
 			return openResultMsg{err}
 		}
@@ -200,11 +206,15 @@ func (m FileEditModel) openInVSCode() tea.Cmd {
 }
 
 // buildBlobURL creates a safe GitHub blob URL for a repository file.
-func buildBlobURL(host, owner, repo, filePath string) (string, error) {
+func buildBlobURL(host, owner, repo, branch, filePath string) (string, error) {
 	owner = strings.TrimSpace(owner)
 	repo = strings.TrimSpace(repo)
+	branch = strings.TrimSpace(branch)
 	if owner == "" || repo == "" {
 		return "", fmt.Errorf("invalid repository reference")
+	}
+	if branch == "" {
+		branch = "main"
 	}
 
 	safePath, err := sanitizeRepoPath(filePath)
@@ -213,16 +223,20 @@ func buildBlobURL(host, owner, repo, filePath string) (string, error) {
 	}
 
 	base := &url.URL{Scheme: "https", Host: host}
-	base.Path = path.Join(owner, repo, "blob", "main", safePath)
+	base.Path = path.Join(owner, repo, "blob", branch, safePath)
 	return base.String(), nil
 }
 
 // buildVSCodeBlobURL creates a safe vscode.dev blob URL for a repository file.
-func buildVSCodeBlobURL(owner, repo, filePath string) (string, error) {
+func buildVSCodeBlobURL(owner, repo, branch, filePath string) (string, error) {
 	owner = strings.TrimSpace(owner)
 	repo = strings.TrimSpace(repo)
+	branch = strings.TrimSpace(branch)
 	if owner == "" || repo == "" {
 		return "", fmt.Errorf("invalid repository reference")
+	}
+	if branch == "" {
+		branch = "main"
 	}
 
 	safePath, err := sanitizeRepoPath(filePath)
@@ -231,7 +245,7 @@ func buildVSCodeBlobURL(owner, repo, filePath string) (string, error) {
 	}
 
 	base := &url.URL{Scheme: "https", Host: "vscode.dev"}
-	base.Path = path.Join("github", owner, repo, "blob", "main", safePath)
+	base.Path = path.Join("github", owner, repo, "blob", branch, safePath)
 	return base.String(), nil
 }
 

--- a/internal/ui/file_edit_security_test.go
+++ b/internal/ui/file_edit_security_test.go
@@ -8,7 +8,7 @@ import (
 func TestBuildBlobURL_EscapesUntrustedPathSegments(t *testing.T) {
 	t.Parallel()
 
-	got, err := buildBlobURL("github.com", "owner", "repo", "/dir/a&b?.go")
+	got, err := buildBlobURL("github.com", "owner", "repo", "main", "/dir/a&b?.go")
 	if err != nil {
 		t.Fatalf("buildBlobURL returned error: %v", err)
 	}
@@ -22,7 +22,7 @@ func TestBuildBlobURL_EscapesUntrustedPathSegments(t *testing.T) {
 func TestBuildVSCodeBlobURL_EscapesPathAndUsesVSCodeHost(t *testing.T) {
 	t.Parallel()
 
-	got, err := buildVSCodeBlobURL("owner", "repo", "/folder/name with spaces.ts")
+	got, err := buildVSCodeBlobURL("owner", "repo", "main", "/folder/name with spaces.ts")
 	if err != nil {
 		t.Fatalf("buildVSCodeBlobURL returned error: %v", err)
 	}
@@ -30,6 +30,20 @@ func TestBuildVSCodeBlobURL_EscapesPathAndUsesVSCodeHost(t *testing.T) {
 	want := "https://vscode.dev/github/owner/repo/blob/main/folder/name%20with%20spaces.ts"
 	if got != want {
 		t.Fatalf("buildVSCodeBlobURL() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildBlobURL_CustomBranch(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildBlobURL("github.com", "owner", "repo", "master", "/dir/file.go")
+	if err != nil {
+		t.Fatalf("buildBlobURL returned error: %v", err)
+	}
+
+	want := "https://github.com/owner/repo/blob/master/dir/file.go"
+	if got != want {
+		t.Fatalf("buildBlobURL() = %q, want %q", got, want)
 	}
 }
 
@@ -41,19 +55,20 @@ func TestBuildBlobURL_RejectsInvalidInputs(t *testing.T) {
 		host     string
 		owner    string
 		repo     string
+		branch   string
 		filePath string
 	}{
-		{name: "empty owner", host: "github.com", owner: "", repo: "repo", filePath: "/main.go"},
-		{name: "empty repo", host: "github.com", owner: "owner", repo: "", filePath: "/main.go"},
-		{name: "empty file path", host: "github.com", owner: "owner", repo: "repo", filePath: ""},
-		{name: "slash-only file path", host: "github.com", owner: "owner", repo: "repo", filePath: "/"},
+		{name: "empty owner", host: "github.com", owner: "", repo: "repo", branch: "main", filePath: "/main.go"},
+		{name: "empty repo", host: "github.com", owner: "owner", repo: "", branch: "main", filePath: "/main.go"},
+		{name: "empty file path", host: "github.com", owner: "owner", repo: "repo", branch: "main", filePath: ""},
+		{name: "slash-only file path", host: "github.com", owner: "owner", repo: "repo", branch: "main", filePath: "/"},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := buildBlobURL(tt.host, tt.owner, tt.repo, tt.filePath)
+			_, err := buildBlobURL(tt.host, tt.owner, tt.repo, tt.branch, tt.filePath)
 			if err == nil {
 				t.Fatalf("expected error for case %q", tt.name)
 			}


### PR DESCRIPTION
### Description
This Pull Request resolves a bug in the interactive file explorer view where opening files on GitHub or vscode.dev online resulted in a `404 Not Found` error. 

The TUI hardcoded `/blob/main/` in the URL format, breaking browser flow redirections for repositories using custom default branches (such as `master` or `dev`). Additionally, the relative file path was directly concatenated right after the branch name without a path separator (e.g., `main%s` where `filePath` is `cmd/root.go` became `maincmd/root.go`), creating a malformed URL.

Fixes #290 

### Solution
- Added `defaultBranch` tracking to `FileEditModel` and updated `NewFileEditModel` to receive it from the repository's metadata.
- Updated `buildBlobURL` and `buildVSCodeBlobURL` in `internal/ui/file_edit.go` to accept the dynamic `branch` name.
- Integrated dynamic branch retrieval in `internal/ui/app.go` to read and pass the analyzed repository's `DefaultBranch` (defaulting to `"main"` if empty).
- Updated TUI unit tests in `internal/ui/file_edit_security_test.go` to reflect the signature changes and added unit tests specifically verifying custom default branch URL building.

### Changes
* `internal/ui/file_edit.go`: Added default branch to `FileEditModel` and updated helper signatures/logic.
* `internal/ui/app.go`: Dynamic branch retrieval when instantiating `FileEditModel`.
* `internal/ui/file_edit_security_test.go`: Signature updates and custom branch verification tests.

### Verification Results
Ran unit tests in the TUI package:
```
go test ./internal/ui/...
```
Output: ``` ok  github.com/agnivo988/Repo-lyzer/internal/ui  2.197s ```
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File editor now correctly uses the repository's actual default branch when constructing links to open files in GitHub or VS Code, instead of hardcoding "main"

* **Tests**
  * Expanded test coverage for branch handling and input validation in file editing functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->