### PR TITLE
Fix/caching system

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -217,13 +217,51 @@ func (c *Cache) Get(repoName string) (*CacheEntry, bool) {
 	return &cacheEntry, true
 }
 
+// GetWithoutTTLExpiration retrieves a cached analysis if available on disk, ignoring expiration checks
+func (c *Cache) GetWithoutTTLExpiration(repoName string) (*CacheEntry, bool) {
+	if !c.config.Enabled {
+		return nil, false
+	}
+
+	_, exists := c.index.Entries[repoName]
+	if !exists {
+		return nil, false
+	}
+
+	// Load full entry from file
+	filename := repoToFilename(repoName)
+	filePath := filepath.Join(c.cacheDir, "repos", filename)
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, false
+	}
+
+	var cacheEntry CacheEntry
+	if err := json.Unmarshal(data, &cacheEntry); err != nil {
+		return nil, false
+	}
+
+	return &cacheEntry, true
+}
+
 // Set stores an analysis result in the cache
 func (c *Cache) Set(repoName string, analysis interface{}) error {
 	return c.SetWithTTL(repoName, analysis, c.config.TTL)
 }
 
+// SetWithMetadata stores an analysis result and incremental metadata in the cache.
+func (c *Cache) SetWithMetadata(repoName string, analysis interface{}, metadata map[string]string) error {
+	return c.SetWithTTLAndMetadata(repoName, analysis, c.config.TTL, metadata)
+}
+
 // SetWithTTL stores an analysis result in the cache with an explicit TTL.
 func (c *Cache) SetWithTTL(repoName string, analysis interface{}, ttl time.Duration) error {
+	return c.SetWithTTLAndMetadata(repoName, analysis, ttl, nil)
+}
+
+// SetWithTTLAndMetadata stores an analysis result and incremental metadata in the cache with an explicit TTL.
+func (c *Cache) SetWithTTLAndMetadata(repoName string, analysis interface{}, ttl time.Duration, metadata map[string]string) error {
 	if !c.config.Enabled || !c.config.AutoCache {
 		return nil
 	}
@@ -235,12 +273,16 @@ func (c *Cache) SetWithTTL(repoName string, analysis interface{}, ttl time.Durat
 	}
 
 	now := time.Now()
+	if metadata == nil {
+		metadata = make(map[string]string)
+	}
+
 	entry := CacheEntry{
 		RepoName:            repoName,
 		CachedAt:            now,
 		ExpiresAt:           now.Add(ttl),
 		Analysis:            analysisData,
-		IncrementalMetadata: make(map[string]string),
+		IncrementalMetadata: metadata,
 	}
 
 	// Save to file

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -250,3 +250,72 @@ func TestGetCacheDir(t *testing.T) {
 		t.Errorf("getCacheDir() = %s, want %s", dir, expected)
 	}
 }
+
+func TestCache_IncrementalMetadata(t *testing.T) {
+	cache, err := NewCache()
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+
+	testRepo := "test/metadata-repo"
+	testData := "some-analysis"
+	metadata := map[string]string{
+		"file1.go": "hash1",
+		"file2.go": "hash2",
+	}
+
+	err = cache.SetWithMetadata(testRepo, testData, metadata)
+	if err != nil {
+		t.Fatalf("SetWithMetadata() error = %v", err)
+	}
+
+	entry, found := cache.Get(testRepo)
+	if !found {
+		t.Fatal("Get() did not find cached entry")
+	}
+
+	if entry.IncrementalMetadata == nil {
+		t.Fatal("IncrementalMetadata was nil")
+	}
+
+	if entry.IncrementalMetadata["file1.go"] != "hash1" || entry.IncrementalMetadata["file2.go"] != "hash2" {
+		t.Errorf("IncrementalMetadata mismatch: %v", entry.IncrementalMetadata)
+	}
+
+	cache.Delete(testRepo)
+}
+
+func TestCache_GetWithoutTTLExpiration(t *testing.T) {
+	cache, err := NewCache()
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+
+	testRepo := "test/expired-repo"
+	testData := "some-analysis"
+
+	// Set with negative TTL so it is immediately expired
+	err = cache.SetWithTTL(testRepo, testData, -1*time.Second)
+	if err != nil {
+		t.Fatalf("SetWithTTL() error = %v", err)
+	}
+
+	// Should not be found via normal Get()
+	_, found := cache.Get(testRepo)
+	if found {
+		t.Error("Get() should not find expired entry")
+	}
+
+	// Should be found via GetWithoutTTLExpiration()
+	entry, found := cache.GetWithoutTTLExpiration(testRepo)
+	if !found {
+		t.Fatal("GetWithoutTTLExpiration() did not find expired entry")
+	}
+
+	if entry == nil {
+		t.Fatal("GetWithoutTTLExpiration() returned nil entry")
+	}
+
+	cache.Delete(testRepo)
+}
+

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -902,24 +902,35 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 		// Compare with cached incremental metadata
 		changedFiles := []string{}
 
-		if entry, found := m.cache.Get(repoName); found {
-			if entry.IncrementalMetadata != nil {
+		if m.cache != nil {
+			if entry, found := m.cache.GetWithoutTTLExpiration(repoName); found {
+				if entry.IncrementalMetadata != nil {
 
-				for path, hash := range currentHashes {
-					cachedHash, exists := entry.IncrementalMetadata[path]
+					for path, hash := range currentHashes {
+						cachedHash, exists := entry.IncrementalMetadata[path]
 
-					// File is new or modified
-					if !exists || cachedHash != hash {
-						changedFiles = append(changedFiles, path)
+						// File is new or modified
+						if !exists || cachedHash != hash {
+							changedFiles = append(changedFiles, path)
+						}
 					}
-				}
 
-				fmt.Printf("🔄 Incremental analysis enabled\n")
-				fmt.Printf("📂 Changed files detected: %d\n", len(changedFiles))
+					fmt.Printf("🔄 Incremental analysis enabled\n")
+					fmt.Printf("📂 Changed files detected: %d\n", len(changedFiles))
 
-				// No changes detected
-				if len(changedFiles) == 0 {
-					fmt.Println("✅ No repository changes detected. Using cached analysis.")
+					// No changes detected
+					if len(changedFiles) == 0 {
+						fmt.Println("✅ No repository changes detected. Using cached analysis.")
+						var result AnalysisResult
+						if err := json.Unmarshal(entry.Analysis, &result); err == nil {
+							// Return cached result with status
+							return CachedAnalysisResult{
+								Result:   result,
+								IsCached: true,
+								CachedAt: entry.CachedAt,
+							}
+						}
+					}
 				}
 			}
 		}
@@ -1052,9 +1063,9 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 			ContributionScore:   contribScore,
 		}
 
-		// Save to cache
+		// Save to cache with file tree hashes metadata
 		if m.cache != nil {
-			m.cache.Set(repoName, result)
+			m.cache.SetWithMetadata(repoName, result, currentHashes)
 		}
 
 		// Add success notification


### PR DESCRIPTION
### Description
This Pull Request addresses a critical issue with the repository caching and TUI incremental analysis system, which resulted in blank metadata and complete bypass of incremental analysis advantages.

Fixes #289

1. In `internal/cache/cache.go`, the cache setter `SetWithTTL` initialized `IncrementalMetadata` as an empty map but never populated it with the repository's file tree hashes before writing the cache entry to disk.
2. In `internal/ui/app.go`'s `analyzeRepo` function, there were two cache checks. The first check returned early with the cached result. The second check (at line 905) compared file hashes but was unreachable because `Get(repoName)` would return `_, false` if the cache was missing or expired, and otherwise the function already exited. 
3. Even if reached, there was no early return when `len(changedFiles) == 0` was detected; it printed "Using cached analysis" to stdout but continued to execute all downstream expensive analysis stages anyway.

### Solution
- Implemented `GetWithoutTTLExpiration(repoName)` in `internal/cache/cache.go` to retrieve a cached entry from disk even if it has expired.
- Added `SetWithMetadata` and `SetWithTTLAndMetadata` to persist analysis data alongside `IncrementalMetadata` file hashes map, keeping `SetWithTTL` backward-compatible.
- Updated `analyzeRepo` in `internal/ui/app.go` to use `GetWithoutTTLExpiration` to check for incremental file tree changes. If `len(changedFiles) == 0`, the TUI returns `CachedAnalysisResult` early, bypassing all downstream analysis stages.
- Updated `analyzeRepo`'s cache save step to call `SetWithMetadata` passing `currentHashes`.
- Added unit tests in `internal/cache/cache_test.go` verifying metadata persistence and expired cache entry retrieval.

### Changes
* `internal/cache/cache.go`: Added `GetWithoutTTLExpiration`, `SetWithMetadata`, `SetWithTTLAndMetadata`, and refactored `SetWithTTL`.
* `internal/cache/cache_test.go`: Added `TestCache_IncrementalMetadata` and `TestCache_GetWithoutTTLExpiration` to test metadata saving and loading.
* `internal/ui/app.go`: Integrated incremental analysis checks and early exits on zero changes.

### Verification Results
Ran unit tests in the cache package:
```
go test ./internal/cache/...
```
Output: ``` ok  github.com/agnivo988/Repo-lyzer/internal/cache  1.254s ```
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved repository analysis performance by detecting unchanged files and reusing cached results, eliminating redundant re-analysis.

* **Bug Fixes**
  * Enhanced cache handling to properly store and retrieve incremental file metadata for more accurate cache management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->