### PR TITLE
fix(trends): compute average issue resolution time from actual data

### DIFF
--- a/internal/analyzer/trends.go
+++ b/internal/analyzer/trends.go
@@ -336,8 +336,20 @@ func analyzeIssueTrendsForTrends(issues []github.Issue, monthlyData []MonthlyMet
 		trend = TrendStable
 	}
 
-	// Average resolution time (simplified - would need actual issue timestamps)
-	avgResolution := 7 * 24 * time.Hour // Default to 7 days
+	// Compute average resolution time from closed issues with valid timestamps.
+	// Fall back to a 7-day estimate only when no closed-issue data is available.
+	avgResolution := 7 * 24 * time.Hour // fallback when there is no data
+	var totalDuration time.Duration
+	var closedCount int
+	for _, issue := range issues {
+		if issue.State == "closed" && issue.ClosedAt != nil {
+			totalDuration += issue.ClosedAt.Sub(issue.CreatedAt)
+			closedCount++
+		}
+	}
+	if closedCount > 0 {
+		avgResolution = totalDuration / time.Duration(closedCount)
+	}
 
 	return trend, avgResolution, resolutionRate
 }


### PR DESCRIPTION
## Summary

`analyzeIssueTrendsForTrends` always returned a hardcoded 7-day average resolution time, making `AvgResolutionTime` meaningless regardless of how quickly a project actually resolves issues.

The `Issue` struct already carries `CreatedAt` and `ClosedAt` timestamps (added in a recent change). This PR uses them to compute the real mean time-to-close across all closed issues. The 7-day estimate is kept as a fallback only when no closed-issue data is available.

## Changes

**`internal/analyzer/trends.go`**:
- Iterate over the `issues` slice; for each closed issue with a valid `ClosedAt`, accumulate `ClosedAt - CreatedAt`
- Divide by the count of closed issues to get the true mean
- Keep the `7 * 24 * time.Hour` constant as a defensive fallback for repositories with no closed issues

## Related

The `IssuesOpened`/`IssuesClosed` aggregation and the `-10` health-score penalty were addressed by #312. This PR completes the fix described in #306 by making `AvgResolutionTime` reflect genuine project activity.

Closes #306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of issue resolution metrics calculation by using actual closed issue data instead of default assumptions.
  * Added fallback mechanism to ensure stability when historical data is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->