### PR TITLE
fix: persist analysis results across page refreshes

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -122,7 +122,9 @@ func NewMainModel(cache *cache.Cache, config *config.AppSettings) MainModel {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-	return MainModel{
+
+	// Restore last analysis result so it persists across page refreshes
+	model := MainModel{
 		state:          stateMenu,
 		menu:           NewMenuModel(),
 		input:          NewInputModel(),
@@ -143,6 +145,16 @@ func NewMainModel(cache *cache.Cache, config *config.AppSettings) MainModel {
 		appConfig:      config,
 		spinner:        s,
 	}
+
+	// Restore previous analysis result from disk so it survives refreshes
+	if saved, err := LoadCurrentAnalysis(); err == nil && saved != nil {
+		model.dashboard.SetData(*saved)
+		model.dashboard.SetCacheStatus("cached")
+		model.state = stateDashboard
+		model.cacheStatus = "cached"
+	}
+
+	return model
 }
 
 // Init initializes the Bubble Tea program
@@ -334,6 +346,10 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.history.Entries = history.Entries
 			m.history.AddEntry(result)
 			m.history.Save()
+			// Persist current analysis so it survives refresh
+			if err := SaveCurrentAnalysis(result); err != nil {
+				log.Printf("Failed to persist current analysis: %v", err)
+			}
 		}
 		if cachedResult, ok := msg.(CachedAnalysisResult); ok {
 			m.dashboard.SetData(cachedResult.Result)
@@ -347,6 +363,10 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.history.Entries = history.Entries
 			m.history.AddEntry(cachedResult.Result)
 			m.history.Save()
+			// Persist current analysis so it survives refresh
+			if err := SaveCurrentAnalysis(cachedResult.Result); err != nil {
+				log.Printf("Failed to persist cached analysis: %v", err)
+			}
 		}
 		if err, ok := msg.(error); ok {
 			m.progress = nil

--- a/internal/ui/current_analysis.go
+++ b/internal/ui/current_analysis.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+const currentAnalysisFile = "exports/current_analysis.json"
+
+func SaveCurrentAnalysis(result AnalysisResult) error {
+	if err := os.MkdirAll(filepath.Dir(currentAnalysisFile), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(currentAnalysisFile, data, 0o644)
+}
+
+func LoadCurrentAnalysis() (*AnalysisResult, error) {
+	data, err := os.ReadFile(currentAnalysisFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var result AnalysisResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func ClearCurrentAnalysis() error {
+	if err := os.MkdirAll(filepath.Dir(currentAnalysisFile), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(currentAnalysisFile, []byte("null"), 0o644)
+}


### PR DESCRIPTION
## Description

Analysis results are now saved to disk when received and automatically restored on app startup, so they persist across page refreshes or terminal reinitializations.

### Changes:
- Added current_analysis.go with SaveCurrentAnalysis/LoadCurrentAnalysis helpers
- Results are persisted to exports/current_analysis.json after each analysis
- On startup, NewMainModel restores the last saved result and shows the dashboard immediately
- Works for both fresh and cached analysis results

Closes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Analysis results are now automatically saved and restored between app sessions
* Dashboard automatically loads and displays the most recent cached analysis on startup
* Your previous analysis data persists and remains readily accessible when you reopen the application

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #282