### PR TITLE
fix: implement --save flag to write analysis JSON to file (#341)

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -300,8 +300,23 @@ var analyzeCmd = &cobra.Command{
 
 		// Track analysis duration
 		duration := time.Since(startTime)
+		savePath, _ := cmd.Flags().GetString("save")
 
 		if compact {
+			if savePath != "" {
+				output.SaveJSON(output.CompactConfig{
+					Repo:            repoInfo,
+					HealthScore:     score,
+					BusFactor:       busFactor,
+					BusRisk:         busRisk,
+					MaturityScore:   maturityScore,
+					MaturityLevel:   maturityLevel,
+					CommitsLastYear: len(commits),
+					Contributors:    len(contributors),
+					Duration:        duration,
+					Languages:       langs,
+				}, savePath)
+			}
 			return output.PrintCompactJSON(output.CompactConfig{
 				Repo:            repoInfo,
 				HealthScore:     score,
@@ -362,6 +377,21 @@ var analyzeCmd = &cobra.Command{
 
 		// Mark analysis as complete
 		overallProgress.Finish()
+
+		if savePath != "" {
+			output.SaveJSON(output.CompactConfig{
+				Repo:            repoInfo,
+				HealthScore:     score,
+				BusFactor:       busFactor,
+				BusRisk:         busRisk,
+				MaturityScore:   maturityScore,
+				MaturityLevel:   maturityLevel,
+				CommitsLastYear: len(commits),
+				Contributors:    len(contributors),
+				Duration:        duration,
+				Languages:       langs,
+			}, savePath)
+		}
 
 		return nil
 	},

--- a/internal/output/compact.go
+++ b/internal/output/compact.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"sort"
 	"time"
@@ -21,6 +22,60 @@ type CompactConfig struct {
 	Contributors    int
 	Duration        time.Duration
 	Languages       map[string]int
+}
+
+// SaveJSON writes the compact analysis summary to a JSON file.
+func SaveJSON(cfg CompactConfig, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("cannot create save file: %w", err)
+	}
+	defer f.Close()
+
+	if cfg.Repo == nil {
+		cfg.Repo = &github.Repo{}
+	}
+
+	topLangs := buildTopLanguages(cfg.Languages, 3)
+	primaryLanguage := cfg.Repo.Language
+	if primaryLanguage == "" && len(topLangs) > 0 {
+		primaryLanguage = topLangs[0].Name
+	}
+
+	summary := compactAnalysis{
+		Repository: compactRepository{
+			FullName:        cfg.Repo.FullName,
+			Description:     cfg.Repo.Description,
+			URL:             cfg.Repo.HTMLURL,
+			PrimaryLanguage: primaryLanguage,
+			Stars:           cfg.Repo.Stars,
+			Forks:           cfg.Repo.Forks,
+			OpenIssues:      cfg.Repo.OpenIssues,
+		},
+		Metrics: compactMetrics{
+			HealthScore:     cfg.HealthScore,
+			BusFactor:       cfg.BusFactor,
+			BusRisk:         cfg.BusRisk,
+			MaturityScore:   cfg.MaturityScore,
+			MaturityLevel:   cfg.MaturityLevel,
+			CommitsLastYear: cfg.CommitsLastYear,
+			Contributors:    cfg.Contributors,
+		},
+		Metadata: compactMetadata{
+			DurationSeconds: cfg.Duration.Seconds(),
+			TopLanguages:    topLangs,
+		},
+	}
+
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(summary); err != nil {
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+
+	fmt.Printf("✅ Analysis saved to %s\n", path)
+	return nil
 }
 
 // PrintCompactJSON writes the compact analysis summary to stdout.


### PR DESCRIPTION
## Summary

The \--save\ flag was registered in \cmd/analyze.go\ but never read by the \RunE\ handler. Running \epo-lyzer analyze owner/repo --save output.json\ silently did nothing.

## Changes

- Read \savePath\ from cobra flags in the analyze \RunE\ handler
- Added \SaveJSON\ function to \internal/output/compact.go\ - writes the same compact analysis data to a JSON file
- Shows a confirmation message after saving: \? Analysis saved to output.json\
- Works with both compact and full output modes

## Testing

- \epo-lyzer analyze owner/repo --save output.json\ now creates the file
- \epo-lyzer analyze owner/repo --compact --save output.json\ also works
- Existing behavior unchanged when \--save\ is omitted

Closes #341 (GSSoC 2026)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The analyze command now supports saving results to a file using the `--save` flag, preserving key metrics including repository health, maturity, contributor statistics, and language information in JSON format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->