### PR TITLE
fix(tui): preserve submenu routing selections

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -145,6 +145,51 @@ func NewMainModel(cache *cache.Cache, config *config.AppSettings) MainModel {
 	}
 }
 
+func analysisTypeForSubmenu(index int) string {
+	switch index {
+	case 0:
+		return "quick"
+	case 1:
+		return "detailed"
+	case 2:
+		return "custom"
+	default:
+		return ""
+	}
+}
+
+func settingsOptionForSubmenu(index int) string {
+	switch index {
+	case 0:
+		return "theme"
+	case 1:
+		return "cache"
+	case 2:
+		return "export"
+	case 3:
+		return "token"
+	case 4:
+		return "reset"
+	default:
+		return ""
+	}
+}
+
+func helpContentForSubmenu(index int) string {
+	switch index {
+	case 0:
+		return "shortcuts"
+	case 1:
+		return "getting-started"
+	case 2:
+		return "features"
+	case 3:
+		return "troubleshooting"
+	default:
+		return ""
+	}
+}
+
 // Init initializes the Bubble Tea program
 func (m MainModel) Init() tea.Cmd {
 	return m.initialCmd
@@ -192,6 +237,8 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.menu.Done {
 			switch m.menu.SelectedOption {
 			case 0: // Analyze Repository
+				m.analysisType = analysisTypeForSubmenu(m.menu.SelectedSubmenuOption)
+				m.loading.SetAnalysisType(m.analysisType)
 				m.state = stateInput
 			case 1: // Favorites
 				m.state = stateFavorites
@@ -206,8 +253,16 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case 6: // Monitoring
 				m.state = stateMonitorDashboard
 			case 7: // Settings
+				m.settingsOption = settingsOptionForSubmenu(m.menu.SelectedSubmenuOption)
+				m.settings.settingsOption = m.settingsOption
+				m.inTokenInput = false
+				m.tokenInput = ""
+				m.settings.inTokenInput = false
+				m.settings.tokenInput = ""
 				m.state = stateSettings
 			case 8: // Help
+				m.helpContent = helpContentForSubmenu(m.menu.SelectedSubmenuOption)
+				m.help.SetHelpContent(m.helpContent)
 				m.state = stateHelp
 			case 9: // Exit
 				return m, tea.Quit
@@ -488,6 +543,8 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case tea.KeyRunes:
 					m.tokenInput += string(msg.Runes)
 				}
+				m.settings.inTokenInput = m.inTokenInput
+				m.settings.tokenInput = m.tokenInput
 				return m, tea.Batch(cmds...)
 			}
 
@@ -563,6 +620,8 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.settingsOption == "token" {
 					m.inTokenInput = true
 					m.tokenInput = ""
+					m.settings.inTokenInput = true
+					m.settings.tokenInput = ""
 				}
 			case "y":
 				// Confirm reset (reset settings)

--- a/internal/ui/menu.go
+++ b/internal/ui/menu.go
@@ -7,17 +7,19 @@ import (
 )
 
 type MenuModel struct {
-	cursor         int
-	choices        []string
-	SelectedOption int
-	Done           bool
-	width          int
-	height         int
-	inSubmenu      bool
-	submenuType    string
-	submenuCursor  int
-	submenuChoices []string
-	parentCursor   int
+	cursor                int
+	choices               []string
+	SelectedOption        int
+	SelectedSubmenuOption int
+	SelectedSubmenuType   string
+	Done                  bool
+	width                 int
+	height                int
+	inSubmenu             bool
+	submenuType           string
+	submenuCursor         int
+	submenuChoices        []string
+	parentCursor          int
 }
 
 type SubmenuOption struct {
@@ -39,7 +41,8 @@ func NewMenuModel() MenuModel {
 			"❓ Help",
 			"🚪 Exit",
 		},
-		inSubmenu: false,
+		inSubmenu:             false,
+		SelectedSubmenuOption: -1,
 	}
 }
 
@@ -109,15 +112,11 @@ func (m MenuModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.enterSubmenu()
 			} else if m.inSubmenu && idx < len(m.submenuChoices) {
 				m.submenuCursor = idx
-				m.SelectedOption = m.cursor
-				m.Done = true
-				m.inSubmenu = false
+				m.selectSubmenuOption()
 			}
 		case "enter", " ":
 			if m.inSubmenu {
-				m.SelectedOption = m.cursor
-				m.Done = true
-				m.inSubmenu = false
+				m.selectSubmenuOption()
 			} else {
 				m.enterSubmenu()
 			}
@@ -190,6 +189,9 @@ func (m MenuModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *MenuModel) enterSubmenu() {
+	m.SelectedSubmenuOption = -1
+	m.SelectedSubmenuType = ""
+
 	switch m.cursor {
 	case 0: // Analyze Repository
 		m.submenuType = "analyze"
@@ -202,21 +204,33 @@ func (m *MenuModel) enterSubmenu() {
 		m.submenuCursor = 0
 	case 1: // Favorites
 		m.SelectedOption = 1
+		m.SelectedSubmenuOption = -1
+		m.SelectedSubmenuType = ""
 		m.Done = true
 	case 2: // Compare Repositories
 		m.SelectedOption = 2
+		m.SelectedSubmenuOption = -1
+		m.SelectedSubmenuType = ""
 		m.Done = true
 	case 3: // View History
 		m.SelectedOption = 3
+		m.SelectedSubmenuOption = -1
+		m.SelectedSubmenuType = ""
 		m.Done = true
 	case 4: // Clone Repository
 		m.SelectedOption = 4
+		m.SelectedSubmenuOption = -1
+		m.SelectedSubmenuType = ""
 		m.Done = true
 	case 5: // Notification
 		m.SelectedOption = 5
+		m.SelectedSubmenuOption = -1
+		m.SelectedSubmenuType = ""
 		m.Done = true
 	case 6: // Monitoring
 		m.SelectedOption = 6
+		m.SelectedSubmenuOption = -1
+		m.SelectedSubmenuType = ""
 		m.Done = true
 	case 7: // Settings
 		m.submenuType = "settings"
@@ -241,8 +255,18 @@ func (m *MenuModel) enterSubmenu() {
 		m.submenuCursor = 0
 	case 9: // Exit
 		m.SelectedOption = 9
+		m.SelectedSubmenuOption = -1
+		m.SelectedSubmenuType = ""
 		m.Done = true
 	}
+}
+
+func (m *MenuModel) selectSubmenuOption() {
+	m.SelectedOption = m.cursor
+	m.SelectedSubmenuOption = m.submenuCursor
+	m.SelectedSubmenuType = m.submenuType
+	m.Done = true
+	m.inSubmenu = false
 }
 
 func (m MenuModel) View() string {

--- a/internal/ui/menu_routing_test.go
+++ b/internal/ui/menu_routing_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func keyRune(r rune) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+}
+
+func TestMenuModelCapturesSubmenuSelection(t *testing.T) {
+	menu := NewMenuModel()
+	menu.cursor = 7
+	menu.enterSubmenu()
+
+	model, _ := menu.Update(keyRune('4'))
+	updated := model.(MenuModel)
+
+	if !updated.Done {
+		t.Fatal("expected submenu selection to complete menu choice")
+	}
+	if updated.SelectedOption != 7 {
+		t.Fatalf("SelectedOption = %d, want 7", updated.SelectedOption)
+	}
+	if updated.SelectedSubmenuType != "settings" {
+		t.Fatalf("SelectedSubmenuType = %q, want settings", updated.SelectedSubmenuType)
+	}
+	if updated.SelectedSubmenuOption != 3 {
+		t.Fatalf("SelectedSubmenuOption = %d, want 3", updated.SelectedSubmenuOption)
+	}
+}
+
+func TestMainModelRoutesSettingsSubmenu(t *testing.T) {
+	model := NewMainModel(nil, nil)
+
+	next, _ := model.Update(keyRune('8'))
+	model = next.(MainModel)
+	next, _ = model.Update(keyRune('4'))
+	model = next.(MainModel)
+
+	if model.state != stateSettings {
+		t.Fatalf("state = %v, want stateSettings", model.state)
+	}
+	if model.settingsOption != "token" {
+		t.Fatalf("settingsOption = %q, want token", model.settingsOption)
+	}
+	if model.settings.settingsOption != "token" {
+		t.Fatalf("settings model option = %q, want token", model.settings.settingsOption)
+	}
+	if !strings.Contains(model.View(), "GitHub API Token Configuration") {
+		t.Fatalf("settings view did not render token page:\n%s", model.View())
+	}
+
+	next, _ = model.Update(keyRune('i'))
+	model = next.(MainModel)
+
+	if !model.settings.inTokenInput {
+		t.Fatal("expected token input state to sync into settings view model")
+	}
+	if !strings.Contains(model.View(), "Enter GitHub Personal Access Token") {
+		t.Fatalf("settings view did not render token input mode:\n%s", model.View())
+	}
+}
+
+func TestMainModelRoutesHelpSubmenu(t *testing.T) {
+	model := NewMainModel(nil, nil)
+
+	next, _ := model.Update(keyRune('9'))
+	model = next.(MainModel)
+	next, _ = model.Update(keyRune('2'))
+	model = next.(MainModel)
+
+	if model.state != stateHelp {
+		t.Fatalf("state = %v, want stateHelp", model.state)
+	}
+	if model.helpContent != "getting-started" {
+		t.Fatalf("helpContent = %q, want getting-started", model.helpContent)
+	}
+	if !strings.Contains(model.View(), "Getting Started") {
+		t.Fatalf("help view did not render getting started page:\n%s", model.View())
+	}
+}
+
+func TestMainModelPreservesAnalyzeSubmenuChoice(t *testing.T) {
+	model := NewMainModel(nil, nil)
+
+	next, _ := model.Update(keyRune('1'))
+	model = next.(MainModel)
+	next, _ = model.Update(keyRune('2'))
+	model = next.(MainModel)
+
+	if model.state != stateInput {
+		t.Fatalf("state = %v, want stateInput", model.state)
+	}
+	if model.analysisType != "detailed" {
+		t.Fatalf("analysisType = %q, want detailed", model.analysisType)
+	}
+	if model.loading.analysisType != "detailed" {
+		t.Fatalf("loading.analysisType = %q, want detailed", model.loading.analysisType)
+	}
+}


### PR DESCRIPTION
## What
Fixes #314 by preserving which TUI submenu item was selected before routing from the main menu. This lets Settings, Help, and Analyze submenu choices open the intended target screen instead of falling back to the generic parent page.

## How
Added submenu selection metadata to `MenuModel`, set it when a submenu item is chosen, and used that metadata in `MainModel` to route settings, help, and analysis screens. Added regression tests for Settings -> GitHub Token, Help -> Getting Started, and Analyze -> Detailed Analysis routing.

## Testing
- `/tmp/codex-go-go1.24.2/go/bin/gofmt -w internal/ui/menu.go internal/ui/app.go internal/ui/menu_routing_test.go`
- `/tmp/codex-go-go1.24.2/go/bin/go test ./internal/ui`
- `/tmp/codex-go-go1.24.2/go/bin/go list ./... | grep -v '/internal/progress$' | xargs /tmp/codex-go-go1.24.2/go/bin/go test`

## Risks / Notes
The local shell did not have `go` on PATH, so validation used a temporary Go 1.24.2 toolchain matching `go.mod`. The repository has a known unrelated `internal/progress` full-suite hang from prior validation, so broader local validation excludes only that package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced submenu navigation with more responsive keyboard handling for faster menu selection
  * Improved token input state management in settings to ensure changes are properly saved and reflected
  * Strengthened menu routing logic for analysis type, settings options, and help navigation

* **Tests**
  * Added comprehensive UI routing tests to verify menu navigation, selection, and state transitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->