### PR TITLE
Add comparison report exports

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -139,13 +139,20 @@ func fetchCompareInput(client *github.Client, owner, repo string) (output.Compar
 		return output.CompareInput{}, err
 	}
 
-	languages, _ := client.GetLanguages(owner, repo)
-	commits, _ := client.GetCommits(owner, repo, 365)
+	languages, err := client.GetLanguages(owner, repo)
+	if err != nil {
+		return output.CompareInput{}, fmt.Errorf("error fetching languages for %s/%s: %w", owner, repo, err)
+	}
+
+	commits, err := client.GetCommits(owner, repo, 365)
+	if err != nil {
+		return output.CompareInput{}, fmt.Errorf("error fetching commits for %s/%s: %w", owner, repo, err)
+	}
+
 	contributors, err := client.GetContributorsWithAvatars(owner, repo, 15)
 	if err != nil {
 		return output.CompareInput{}, fmt.Errorf("error fetching contributors for %s/%s: %w", owner, repo, err)
 	}
-	_, _ = client.GetFileTree(owner, repo, repoInfo.DefaultBranch)
 
 	return output.CompareInput{
 		Repo:         repoInfo,

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -69,32 +69,35 @@ Examples:
 			format = "terminal"
 		}
 
-		// Parse repo names
-		r1 := strings.Split(args[0], "/")
-		r2 := strings.Split(args[1], "/")
+		// Validate and parse repo names using shared helper
+		owner1, repo1, err := validateRepoURL(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid repository '%s': %w", args[0], err)
+		}
 
-		if len(r1) != 2 || len(r2) != 2 {
-			return fmt.Errorf("repositories must be in owner/repo format")
+		owner2, repo2, err := validateRepoURL(args[1])
+		if err != nil {
+			return fmt.Errorf("invalid repository '%s': %w", args[1], err)
 		}
 
 		client := github.NewClient()
 		spinner := progress.NewSpinner()
 
-		spinner.Start(fmt.Sprintf("🔍 Analyzing %s/%s...", r1[0], r1[1]))
-		side1, err := fetchCompareInput(client, r1[0], r1[1])
+		spinner.Start(fmt.Sprintf("🔍 Analyzing %s/%s...", owner1, repo1))
+		side1, err := fetchCompareInput(client, owner1, repo1)
 		if err != nil {
 			spinner.Stop()
 			return err
 		}
-		spinner.StopWithMessage(fmt.Sprintf("Analyzed %s/%s", r1[0], r1[1]))
+		spinner.StopWithMessage(fmt.Sprintf("Analyzed %s/%s", owner1, repo1))
 
-		spinner.Start(fmt.Sprintf("🔍 Analyzing %s/%s...", r2[0], r2[1]))
-		side2, err := fetchCompareInput(client, r2[0], r2[1])
+		spinner.Start(fmt.Sprintf("🔍 Analyzing %s/%s...", owner2, repo2))
+		side2, err := fetchCompareInput(client, owner2, repo2)
 		if err != nil {
 			spinner.Stop()
 			return err
 		}
-		spinner.StopWithMessage(fmt.Sprintf("Analyzed %s/%s", r2[0], r2[1]))
+		spinner.StopWithMessage(fmt.Sprintf("Analyzed %s/%s", owner2, repo2))
 
 		report := output.BuildCompareReport(side1, side2)
 

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -5,14 +5,13 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
-	"github.com/olekukonko/tablewriter"
-	"github.com/spf13/cobra"
-
-	"github.com/agnivo988/Repo-lyzer/internal/analyzer"
 	"github.com/agnivo988/Repo-lyzer/internal/github"
+	"github.com/agnivo988/Repo-lyzer/internal/output"
 	"github.com/agnivo988/Repo-lyzer/internal/progress"
+	"github.com/spf13/cobra"
 )
 
 // RunCompare executes the compare command for two GitHub repositories.
@@ -36,24 +35,39 @@ var compareCmd = &cobra.Command{
 of their key metrics and health indicators.
 
 Comparison includes:
-  • Stars, Forks, and Open Issues
-  • Commit activity (past year)
-  • Contributor count and engagement
-  • Bus Factor and risk assessment  
-  • Repository maturity scores
-  • Verdict on which repository is more mature/stable
+	• Stars, Forks, and Open Issues
+	• Commit activity (past year)
+	• Contributor count and engagement
+	• Bus Factor and risk assessment  
+	• Repository maturity scores
+	• Verdict on which repository is more mature/stable
 
 Examples:
-  # Compare popular frameworks
-  repo-lyzer compare facebook/react vuejs/vue
+	# Compare popular frameworks
+	repo-lyzer compare facebook/react vuejs/vue
 
-  # Compare similar tools
-  repo-lyzer compare golang/go rust-lang/rust
+	# Compare similar tools
+	repo-lyzer compare golang/go rust-lang/rust
 
-  # Compare forks
-  repo-lyzer compare original/repo fork/repo`,
+	# Compare forks
+	repo-lyzer compare original/repo fork/repo
+
+	# Export as HTML
+	repo-lyzer compare golang/go microsoft/vscode --format html --save report.html
+
+	# Export as JSON
+	repo-lyzer compare golang/go facebook/react --format json --save compare.json
+
+	# Export as Markdown to stdout
+	repo-lyzer compare golang/go rust-lang/rust --format markdown`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		format, _ := cmd.Flags().GetString("format")
+		savePath, _ := cmd.Flags().GetString("save")
+		format = strings.ToLower(strings.TrimSpace(format))
+		if format == "" {
+			format = "terminal"
+		}
 
 		// Parse repo names
 		r1 := strings.Split(args[0], "/")
@@ -64,136 +78,93 @@ Examples:
 		}
 
 		client := github.NewClient()
-
-		// Create progress spinner
 		spinner := progress.NewSpinner()
 
-		// Fetch first repository
 		spinner.Start(fmt.Sprintf("🔍 Analyzing %s/%s...", r1[0], r1[1]))
-		repo1, err := client.GetRepo(r1[0], r1[1])
+		side1, err := fetchCompareInput(client, r1[0], r1[1])
 		if err != nil {
 			spinner.Stop()
 			return err
 		}
-
-		_, _ = client.GetLanguages(r1[0], r1[1])
-		commits1, _ := client.GetCommits(r1[0], r1[1], 365)
-		contributors1, err := client.GetContributorsWithAvatars(r1[0], r1[1], 15)
-		if err != nil {
-			spinner.Stop()
-			fmt.Printf("Error fetching contributors for %s/%s: %v\n", r1[0], r1[1], err)
-			return err
-		}
-		_, _ = client.GetFileTree(r1[0], r1[1], repo1.DefaultBranch)
-		bus1, risk1 := analyzer.BusFactor(contributors1)
-
-		maturityScore1, maturityLevel1 :=
-			analyzer.RepoMaturityScore(repo1, len(commits1), len(contributors1), false)
-
 		spinner.StopWithMessage(fmt.Sprintf("Analyzed %s/%s", r1[0], r1[1]))
 
-		// ---------- Fetch Repo 2 ----------
 		spinner.Start(fmt.Sprintf("🔍 Analyzing %s/%s...", r2[0], r2[1]))
-		repo2, err := client.GetRepo(r2[0], r2[1])
+		side2, err := fetchCompareInput(client, r2[0], r2[1])
 		if err != nil {
 			spinner.Stop()
 			return err
 		}
-
-		_, _ = client.GetLanguages(r2[0], r2[1])
-		commits2, _ := client.GetCommits(r2[0], r2[1], 365)
-		contributors2, err := client.GetContributorsWithAvatars(r2[0], r2[1], 15)
-		if err != nil {
-			spinner.Stop()
-			fmt.Printf("Error fetching contributors for %s/%s: %v\n", r2[0], r2[1], err)
-			return err
-		}
-		_, _ = client.GetFileTree(r2[0], r2[1], repo2.DefaultBranch)
-		bus2, risk2 := analyzer.BusFactor(contributors2)
-
-		maturityScore2, maturityLevel2 :=
-			analyzer.RepoMaturityScore(repo2, len(commits2), len(contributors2), false)
-
 		spinner.StopWithMessage(fmt.Sprintf("Analyzed %s/%s", r2[0], r2[1]))
 
-		// ---------- Output Table ----------
-		fmt.Println("\n📊 Repository Comparison")
+		report := output.BuildCompareReport(side1, side2)
 
-		table := tablewriter.NewWriter(os.Stdout)
-		table.Header([]string{"Metric", repo1.FullName, repo2.FullName})
+		var rendered []byte
+		switch format {
+		case "terminal":
+			terminalOutput := output.RenderCompareTerminal(report)
+			fmt.Print(terminalOutput)
+			if savePath != "" {
+				return saveCompareOutput(savePath, []byte(terminalOutput))
+			}
+			return nil
+		case "json":
+			rendered, err = output.RenderCompareJSON(report)
+		case "markdown":
+			rendered, err = output.RenderCompareMarkdown(report)
+		case "html":
+			rendered, err = output.RenderCompareHTML(report)
+		default:
+			return fmt.Errorf("unsupported compare format: %s", format)
+		}
+		if err != nil {
+			return err
+		}
 
-		table.Append([]string{"⭐ Stars",
-			fmt.Sprintf("%d", repo1.Stars),
-			fmt.Sprintf("%d", repo2.Stars),
-		})
-
-		table.Append([]string{"🍴 Forks",
-			fmt.Sprintf("%d", repo1.Forks),
-			fmt.Sprintf("%d", repo2.Forks),
-		})
-
-		table.Append([]string{"📦 Commits (1y)",
-			fmt.Sprintf("%d", len(commits1)),
-			fmt.Sprintf("%d", len(commits2)),
-		})
-
-		table.Append([]string{"👥 Contributors",
-			fmt.Sprintf("%d", len(contributors1)),
-			fmt.Sprintf("%d", len(contributors2)),
-		})
-
-		table.Append([]string{"⚠️ Bus Factor",
-			fmt.Sprintf("%d (%s)", bus1, risk1),
-			fmt.Sprintf("%d (%s)", bus2, risk2),
-		})
-
-		table.Append([]string{"🏗️ Maturity",
-			fmt.Sprintf("%s (%d)", maturityLevel1, maturityScore1),
-			fmt.Sprintf("%s (%d)", maturityLevel2, maturityScore2),
-		})
-
-		// Check if repositories are identical
-		if repo1.Stars == repo2.Stars &&
-			repo1.Forks == repo2.Forks &&
-			len(commits1) == len(commits2) &&
-			len(contributors1) == len(contributors2) &&
-			bus1 == bus2 &&
-			maturityScore1 == maturityScore2 {
-
-			fmt.Println("\n✅ No differences found between the two repositories.")
-			fmt.Println("Both repositories have identical metrics.")
+		if savePath != "" {
+			if err := saveCompareOutput(savePath, rendered); err != nil {
+				return err
+			}
+			fmt.Printf("Saved comparison report to %s\n", savePath)
 			return nil
 		}
 
-		table.Render()
-
-		// ---------- Verdict ----------
-		fmt.Println("\n Verdict")
-		if maturityScore1 > maturityScore2 {
-			fmt.Printf("➡️ %s appears more mature and stable.\n", repo1.FullName)
-		} else if maturityScore2 > maturityScore1 {
-			fmt.Printf("➡️ %s appears more mature and stable.\n", repo2.FullName)
-		} else {
-			fmt.Println("➡️ Both repositories are similarly mature.")
-		}
-
+		fmt.Print(string(rendered))
 		return nil
 	},
 }
 
-func init() {
-	rootCmd.AddCommand(compareCmd)
+func fetchCompareInput(client *github.Client, owner, repo string) (output.CompareInput, error) {
+	repoInfo, err := client.GetRepo(owner, repo)
+	if err != nil {
+		return output.CompareInput{}, err
+	}
+
+	languages, _ := client.GetLanguages(owner, repo)
+	commits, _ := client.GetCommits(owner, repo, 365)
+	contributors, err := client.GetContributorsWithAvatars(owner, repo, 15)
+	if err != nil {
+		return output.CompareInput{}, fmt.Errorf("error fetching contributors for %s/%s: %w", owner, repo, err)
+	}
+	_, _ = client.GetFileTree(owner, repo, repoInfo.DefaultBranch)
+
+	return output.CompareInput{
+		Repo:         repoInfo,
+		Commits:      commits,
+		Contributors: contributors,
+		Languages:    languages,
+	}, nil
 }
 
-// countTreeStats counts files, directories, and total size from tree entries
-func countTreeStats(tree []github.TreeEntry) (files, dirs, totalSize int) {
-	for _, entry := range tree {
-		if entry.Type == "blob" {
-			files++
-			totalSize += entry.Size
-		} else if entry.Type == "tree" {
-			dirs++
-		}
+func saveCompareOutput(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
 	}
-	return
+
+	return os.WriteFile(path, data, 0644)
+}
+
+func init() {
+	rootCmd.AddCommand(compareCmd)
+	compareCmd.Flags().String("format", "terminal", "Output format: terminal, html, json, markdown")
+	compareCmd.Flags().String("save", "", "Write the comparison output to a file")
 }

--- a/internal/output/compare.go
+++ b/internal/output/compare.go
@@ -28,7 +28,7 @@ type CompareRepository struct {
 	Stars           int            `json:"stars"`
 	Forks           int            `json:"forks"`
 	OpenIssues      int            `json:"open_issues"`
-	CommitsLastYear int            `json:"commits_last_year"`
+	CommitsLastYear int            `json:"commit_count_1y"`
 	Contributors    int            `json:"contributors"`
 	HealthScore     int            `json:"health_score"`
 	BusFactor       int            `json:"bus_factor"`

--- a/internal/output/compare.go
+++ b/internal/output/compare.go
@@ -1,0 +1,256 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/agnivo988/Repo-lyzer/internal/analyzer"
+	"github.com/agnivo988/Repo-lyzer/internal/github"
+	"github.com/olekukonko/tablewriter"
+)
+
+// CompareInput contains the data required to build a repository comparison report.
+type CompareInput struct {
+	Repo         *github.Repo
+	Commits      []github.Commit
+	Contributors []github.Contributor
+	Languages    map[string]int
+}
+
+// CompareRepository contains the computed metrics for one repository.
+type CompareRepository struct {
+	FullName        string         `json:"full_name"`
+	Description     string         `json:"description,omitempty"`
+	Stars           int            `json:"stars"`
+	Forks           int            `json:"forks"`
+	OpenIssues      int            `json:"open_issues"`
+	CommitsLastYear int            `json:"commits_last_year"`
+	Contributors    int            `json:"contributors"`
+	HealthScore     int            `json:"health_score"`
+	BusFactor       int            `json:"bus_factor"`
+	BusRisk         string         `json:"bus_risk"`
+	MaturityScore   int            `json:"maturity_score"`
+	MaturityLevel   string         `json:"maturity_level"`
+	PrimaryLanguage string         `json:"primary_language,omitempty"`
+	Languages       map[string]int `json:"languages,omitempty"`
+}
+
+// CompareReport is the complete comparison payload used by every output format.
+type CompareReport struct {
+	GeneratedAt time.Time        `json:"generated_at"`
+	Repo1       CompareRepository `json:"repo1"`
+	Repo2       CompareRepository `json:"repo2"`
+	Verdict     string           `json:"verdict"`
+}
+
+// IsIdentical reports whether the key terminal metrics are equivalent.
+func (r CompareReport) IsIdentical() bool {
+	return r.Repo1.Stars == r.Repo2.Stars &&
+		r.Repo1.Forks == r.Repo2.Forks &&
+		r.Repo1.CommitsLastYear == r.Repo2.CommitsLastYear &&
+		r.Repo1.Contributors == r.Repo2.Contributors &&
+		r.Repo1.BusFactor == r.Repo2.BusFactor &&
+		r.Repo1.MaturityScore == r.Repo2.MaturityScore
+}
+
+// BuildCompareReport calculates the comparison metrics for two repositories.
+func BuildCompareReport(repo1, repo2 CompareInput) CompareReport {
+	r1 := buildCompareRepository(repo1)
+	r2 := buildCompareRepository(repo2)
+
+	return CompareReport{
+		GeneratedAt: time.Now(),
+		Repo1:       r1,
+		Repo2:       r2,
+		Verdict:     BuildCompareVerdict(r1, r2),
+	}
+}
+
+// BuildCompareVerdict summarizes which repository appears more mature.
+func BuildCompareVerdict(repo1, repo2 CompareRepository) string {
+	if repo1.MaturityScore > repo2.MaturityScore {
+		return fmt.Sprintf("➡️ %s appears more mature and stable.", repo1.FullName)
+	}
+
+	if repo2.MaturityScore > repo1.MaturityScore {
+		return fmt.Sprintf("➡️ %s appears more mature and stable.", repo2.FullName)
+	}
+
+	return "➡️ Both repositories are similarly mature."
+}
+
+// RenderCompareTerminal renders the legacy terminal comparison output.
+func RenderCompareTerminal(report CompareReport) string {
+	var buf bytes.Buffer
+	buf.WriteString("\n📊 Repository Comparison\n")
+
+	if report.IsIdentical() {
+		buf.WriteString("\n✅ No differences found between the two repositories.\n")
+		buf.WriteString("Both repositories have identical metrics.\n")
+		return buf.String()
+	}
+
+	table := tablewriter.NewWriter(&buf)
+	table.Header([]string{"Metric", report.Repo1.FullName, report.Repo2.FullName})
+
+	table.Append([]string{"⭐ Stars",
+		fmt.Sprintf("%d", report.Repo1.Stars),
+		fmt.Sprintf("%d", report.Repo2.Stars),
+	})
+
+	table.Append([]string{"🍴 Forks",
+		fmt.Sprintf("%d", report.Repo1.Forks),
+		fmt.Sprintf("%d", report.Repo2.Forks),
+	})
+
+	table.Append([]string{"📦 Commits (1y)",
+		fmt.Sprintf("%d", report.Repo1.CommitsLastYear),
+		fmt.Sprintf("%d", report.Repo2.CommitsLastYear),
+	})
+
+	table.Append([]string{"👥 Contributors",
+		fmt.Sprintf("%d", report.Repo1.Contributors),
+		fmt.Sprintf("%d", report.Repo2.Contributors),
+	})
+
+	table.Append([]string{"⚠️ Bus Factor",
+		fmt.Sprintf("%d (%s)", report.Repo1.BusFactor, report.Repo1.BusRisk),
+		fmt.Sprintf("%d (%s)", report.Repo2.BusFactor, report.Repo2.BusRisk),
+	})
+
+	table.Append([]string{"🏗️ Maturity",
+		fmt.Sprintf("%s (%d)", report.Repo1.MaturityLevel, report.Repo1.MaturityScore),
+		fmt.Sprintf("%s (%d)", report.Repo2.MaturityLevel, report.Repo2.MaturityScore),
+	})
+
+	table.Render()
+
+	buf.WriteString("\n Verdict\n")
+	buf.WriteString(report.Verdict)
+	buf.WriteString("\n")
+
+	return buf.String()
+}
+
+// RenderCompareJSON renders the full comparison report as indented JSON.
+func RenderCompareJSON(report CompareReport) ([]byte, error) {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal comparison report to JSON: %w", err)
+	}
+
+	return append(data, '\n'), nil
+}
+
+// RenderCompareMarkdown renders the comparison report as markdown.
+func RenderCompareMarkdown(report CompareReport) ([]byte, error) {
+	var buf strings.Builder
+
+	buf.WriteString(fmt.Sprintf("# Repository Comparison: %s vs %s\n\n", report.Repo1.FullName, report.Repo2.FullName))
+	buf.WriteString(fmt.Sprintf("*Generated: %s*\n\n", report.GeneratedAt.Format(time.RFC3339)))
+
+	buf.WriteString("## Summary\n\n")
+	buf.WriteString(fmt.Sprintf("| Metric | %s | %s |\n", report.Repo1.FullName, report.Repo2.FullName))
+	buf.WriteString("| --- | --- | --- |\n")
+	buf.WriteString(fmt.Sprintf("| Stars | %d | %d |\n", report.Repo1.Stars, report.Repo2.Stars))
+	buf.WriteString(fmt.Sprintf("| Forks | %d | %d |\n", report.Repo1.Forks, report.Repo2.Forks))
+	buf.WriteString(fmt.Sprintf("| Open Issues | %d | %d |\n", report.Repo1.OpenIssues, report.Repo2.OpenIssues))
+	buf.WriteString(fmt.Sprintf("| Commits (1y) | %d | %d |\n", report.Repo1.CommitsLastYear, report.Repo2.CommitsLastYear))
+	buf.WriteString(fmt.Sprintf("| Contributors | %d | %d |\n", report.Repo1.Contributors, report.Repo2.Contributors))
+	buf.WriteString(fmt.Sprintf("| Health Score | %d | %d |\n", report.Repo1.HealthScore, report.Repo2.HealthScore))
+	buf.WriteString(fmt.Sprintf("| Bus Factor | %d (%s) | %d (%s) |\n", report.Repo1.BusFactor, report.Repo1.BusRisk, report.Repo2.BusFactor, report.Repo2.BusRisk))
+	buf.WriteString(fmt.Sprintf("| Maturity | %s (%d) | %s (%d) |\n", report.Repo1.MaturityLevel, report.Repo1.MaturityScore, report.Repo2.MaturityLevel, report.Repo2.MaturityScore))
+	buf.WriteString(fmt.Sprintf("| Primary Language | %s | %s |\n", displayOrUnknown(report.Repo1.PrimaryLanguage), displayOrUnknown(report.Repo2.PrimaryLanguage)))
+
+	buf.WriteString("\n## Verdict\n\n")
+	buf.WriteString(report.Verdict)
+	buf.WriteString("\n")
+
+	return []byte(buf.String()), nil
+}
+
+func buildCompareRepository(input CompareInput) CompareRepository {
+	if input.Repo == nil {
+		return CompareRepository{}
+	}
+
+	busFactor, busRisk := analyzer.BusFactor(input.Contributors)
+	maturityScore, maturityLevel := analyzer.RepoMaturityScore(input.Repo, len(input.Commits), len(input.Contributors), false)
+	healthScore := analyzer.CalculateHealth(input.Repo, input.Commits)
+
+	primaryLanguage := input.Repo.Language
+	if primaryLanguage == "" {
+		primaryLanguage = topLanguageName(input.Languages)
+	}
+
+	return CompareRepository{
+		FullName:        input.Repo.FullName,
+		Description:     input.Repo.Description,
+		Stars:           input.Repo.Stars,
+		Forks:           input.Repo.Forks,
+		OpenIssues:      input.Repo.OpenIssues,
+		CommitsLastYear: len(input.Commits),
+		Contributors:    len(input.Contributors),
+		HealthScore:     healthScore,
+		BusFactor:       busFactor,
+		BusRisk:         busRisk,
+		MaturityScore:   maturityScore,
+		MaturityLevel:   maturityLevel,
+		PrimaryLanguage: primaryLanguage,
+		Languages:       copyLanguageMap(input.Languages),
+	}
+}
+
+func topLanguageName(languages map[string]int) string {
+	if len(languages) == 0 {
+		return ""
+	}
+
+	type languageEntry struct {
+		name string
+		size int
+	}
+
+	entries := make([]languageEntry, 0, len(languages))
+	for name, size := range languages {
+		if size <= 0 {
+			continue
+		}
+		entries = append(entries, languageEntry{name: name, size: size})
+	}
+
+	if len(entries) == 0 {
+		return ""
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].size > entries[j].size
+	})
+
+	return entries[0].name
+}
+
+func copyLanguageMap(languages map[string]int) map[string]int {
+	if len(languages) == 0 {
+		return nil
+	}
+
+	copyMap := make(map[string]int, len(languages))
+	for name, size := range languages {
+		copyMap[name] = size
+	}
+
+	return copyMap
+}
+
+func displayOrUnknown(value string) string {
+	if value == "" {
+		return "Unknown"
+	}
+
+	return value
+}

--- a/internal/output/compare_html.go
+++ b/internal/output/compare_html.go
@@ -12,9 +12,7 @@ import (
 //go:embed templates/compare.html
 var compareTemplateFS embed.FS
 
-var compareHTMLTemplate = template.Must(template.New("compare.html").Funcs(template.FuncMap{
-	"scoreClass": scoreClass,
-}).ParseFS(compareTemplateFS, "templates/compare.html"))
+var compareHTMLTemplate = template.Must(template.New("compare.html").ParseFS(compareTemplateFS, "templates/compare.html"))
 
 type compareHTMLData struct {
 	GeneratedAt string

--- a/internal/output/compare_html.go
+++ b/internal/output/compare_html.go
@@ -1,0 +1,225 @@
+package output
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"html/template"
+	"sort"
+	"strings"
+	"time"
+)
+
+//go:embed templates/compare.html
+var compareTemplateFS embed.FS
+
+var compareHTMLTemplate = template.Must(template.New("compare.html").Funcs(template.FuncMap{
+	"scoreClass": scoreClass,
+}).ParseFS(compareTemplateFS, "templates/compare.html"))
+
+type compareHTMLData struct {
+	GeneratedAt string
+	Verdict     string
+	Repo1       compareHTMLRepo
+	Repo2       compareHTMLRepo
+	Metrics     []compareHTMLMetric
+}
+
+type compareHTMLRepo struct {
+	FullName        string
+	Description     string
+	PrimaryLanguage string
+	Stars           int
+	Forks           int
+	OpenIssues      int
+	CommitsLastYear int
+	Contributors    int
+	HealthScore     int
+	BusFactor       int
+	BusRisk         string
+	MaturityScore   int
+	MaturityLevel   string
+	HealthClass     string
+	Languages       []compareLanguageShare
+}
+
+type compareHTMLMetric struct {
+	Label      string
+	Left       string
+	Right      string
+	LeftClass  string
+	RightClass string
+}
+
+type compareLanguageShare struct {
+	Name       string
+	Percent    float64
+	Width      int
+	Percentage string
+}
+
+// RenderCompareHTML renders the report as a polished HTML document.
+func RenderCompareHTML(report CompareReport) ([]byte, error) {
+	data := compareHTMLData{
+		GeneratedAt: report.GeneratedAt.Format(time.RFC3339),
+		Verdict:     report.Verdict,
+		Repo1:       buildCompareHTMLRepo(report.Repo1),
+		Repo2:       buildCompareHTMLRepo(report.Repo2),
+		Metrics:     buildCompareHTMLMetrics(report),
+	}
+
+	var buf bytes.Buffer
+	if err := compareHTMLTemplate.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("failed to render comparison HTML: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func buildCompareHTMLRepo(repo CompareRepository) compareHTMLRepo {
+	return compareHTMLRepo{
+		FullName:        repo.FullName,
+		Description:     repo.Description,
+		PrimaryLanguage: displayOrUnknown(repo.PrimaryLanguage),
+		Stars:           repo.Stars,
+		Forks:           repo.Forks,
+		OpenIssues:      repo.OpenIssues,
+		CommitsLastYear: repo.CommitsLastYear,
+		Contributors:    repo.Contributors,
+		HealthScore:     repo.HealthScore,
+		BusFactor:       repo.BusFactor,
+		BusRisk:         repo.BusRisk,
+		MaturityScore:   repo.MaturityScore,
+		MaturityLevel:   repo.MaturityLevel,
+		HealthClass:     scoreClass(repo.HealthScore),
+		Languages:       buildCompareLanguageShares(repo.Languages, 5),
+	}
+}
+
+func buildCompareHTMLMetrics(report CompareReport) []compareHTMLMetric {
+	return []compareHTMLMetric{
+		metricRow("Stars", report.Repo1.Stars, report.Repo2.Stars, true),
+		metricRow("Forks", report.Repo1.Forks, report.Repo2.Forks, true),
+		metricRow("Open Issues", report.Repo1.OpenIssues, report.Repo2.OpenIssues, false),
+		metricRow("Commits (1y)", report.Repo1.CommitsLastYear, report.Repo2.CommitsLastYear, true),
+		metricRow("Contributors", report.Repo1.Contributors, report.Repo2.Contributors, true),
+		metricRow("Health Score", report.Repo1.HealthScore, report.Repo2.HealthScore, true),
+		metricRow("Bus Factor", report.Repo1.BusFactor, report.Repo2.BusFactor, true),
+		metricRow("Maturity Score", report.Repo1.MaturityScore, report.Repo2.MaturityScore, true),
+		{
+			Label:      "Primary Language",
+			Left:       displayOrUnknown(report.Repo1.PrimaryLanguage),
+			Right:      displayOrUnknown(report.Repo2.PrimaryLanguage),
+			LeftClass:  "",
+			RightClass: "",
+		},
+	}
+}
+
+func metricRow(label string, left, right int, higherIsBetter bool) compareHTMLMetric {
+	leftClass, rightClass := "", ""
+	if left > right {
+		if higherIsBetter {
+			leftClass = "metric-better"
+			rightClass = "metric-worse"
+		} else {
+			leftClass = "metric-worse"
+			rightClass = "metric-better"
+		}
+	} else if right > left {
+		if higherIsBetter {
+			leftClass = "metric-worse"
+			rightClass = "metric-better"
+		} else {
+			leftClass = "metric-better"
+			rightClass = "metric-worse"
+		}
+	}
+
+	return compareHTMLMetric{
+		Label:      label,
+		Left:       fmt.Sprintf("%d", left),
+		Right:      fmt.Sprintf("%d", right),
+		LeftClass:  leftClass,
+		RightClass: rightClass,
+	}
+}
+
+func buildCompareLanguageShares(languages map[string]int, limit int) []compareLanguageShare {
+	if len(languages) == 0 || limit <= 0 {
+		return nil
+	}
+
+	type languageEntry struct {
+		name string
+		size int
+	}
+
+	entries := make([]languageEntry, 0, len(languages))
+	total := 0
+	for name, size := range languages {
+		if size <= 0 {
+			continue
+		}
+		total += size
+		entries = append(entries, languageEntry{name: name, size: size})
+	}
+
+	if total == 0 || len(entries) == 0 {
+		return nil
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].size > entries[j].size
+	})
+
+	if limit > len(entries) {
+		limit = len(entries)
+	}
+
+	shares := make([]compareLanguageShare, 0, limit)
+	for _, entry := range entries[:limit] {
+		percent := float64(entry.size) / float64(total) * 100
+		width := int(percent)
+		if width < 4 {
+			width = 4
+		}
+		if width > 100 {
+			width = 100
+		}
+
+		shares = append(shares, compareLanguageShare{
+			Name:       entry.name,
+			Percent:    percent,
+			Width:      width,
+			Percentage: fmt.Sprintf("%.1f%%", percent),
+		})
+	}
+
+	return shares
+}
+
+func scoreClass(score int) string {
+	switch {
+	case score >= 80:
+		return "score-good"
+	case score >= 60:
+		return "score-warning"
+	default:
+		return "score-bad"
+	}
+}
+
+func (r compareHTMLRepo) HasLanguages() bool {
+	return len(r.Languages) > 0
+}
+
+func joinClasses(parts ...string) string {
+	classes := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			classes = append(classes, part)
+		}
+	}
+	return strings.Join(classes, " ")
+}

--- a/internal/output/compare_html.go
+++ b/internal/output/compare_html.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -210,16 +209,4 @@ func scoreClass(score int) string {
 	}
 }
 
-func (r compareHTMLRepo) HasLanguages() bool {
-	return len(r.Languages) > 0
-}
-
-func joinClasses(parts ...string) string {
-	classes := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if part != "" {
-			classes = append(classes, part)
-		}
-	}
-	return strings.Join(classes, " ")
-}
+// removed unused helpers: HasLanguages, joinClasses

--- a/internal/output/compare_test.go
+++ b/internal/output/compare_test.go
@@ -1,0 +1,102 @@
+package output
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agnivo988/Repo-lyzer/internal/github"
+)
+
+func TestBuildCompareReport(t *testing.T) {
+	report := BuildCompareReport(
+		CompareInput{
+			Repo: &github.Repo{
+				FullName:      "owner/alpha",
+				Description:   "Alpha repo",
+				Stars:         120,
+				Forks:         18,
+				OpenIssues:    7,
+				Language:      "Go",
+				DefaultBranch: "main",
+				PushedAt:      time.Now().Add(-24 * time.Hour),
+			},
+			Commits: []github.Commit{{}, {}, {}},
+			Contributors: []github.Contributor{{}, {}},
+			Languages: map[string]int{"Go": 1000, "Shell": 100},
+		},
+		CompareInput{
+			Repo: &github.Repo{
+				FullName:      "owner/beta",
+				Description:   "Beta repo",
+				Stars:         80,
+				Forks:         12,
+				OpenIssues:    10,
+				Language:      "TypeScript",
+				DefaultBranch: "main",
+				PushedAt:      time.Now().Add(-48 * time.Hour),
+			},
+			Commits: []github.Commit{{}, {}},
+			Contributors: []github.Contributor{{}},
+			Languages: map[string]int{"TypeScript": 900, "CSS": 50},
+		},
+	)
+
+	if report.Repo1.FullName != "owner/alpha" || report.Repo2.FullName != "owner/beta" {
+		t.Fatalf("unexpected repo names: %#v", report)
+	}
+
+	if report.Verdict == "" {
+		t.Fatal("expected a non-empty verdict")
+	}
+
+	if report.Repo1.HealthScore == 0 || report.Repo2.HealthScore == 0 {
+		t.Fatal("expected health scores to be computed")
+	}
+}
+
+func TestRenderCompareOutputs(t *testing.T) {
+	report := BuildCompareReport(
+		CompareInput{
+			Repo: &github.Repo{FullName: "owner/alpha", Stars: 10, Forks: 4, OpenIssues: 1, Language: "Go", DefaultBranch: "main"},
+			Commits: []github.Commit{{}},
+			Contributors: []github.Contributor{{}},
+			Languages: map[string]int{"Go": 1},
+		},
+		CompareInput{
+			Repo: &github.Repo{FullName: "owner/beta", Stars: 20, Forks: 6, OpenIssues: 2, Language: "Rust", DefaultBranch: "main"},
+			Commits: []github.Commit{{}, {}},
+			Contributors: []github.Contributor{{}, {}},
+			Languages: map[string]int{"Rust": 2},
+		},
+	)
+
+	terminal := RenderCompareTerminal(report)
+	if !strings.Contains(terminal, "Repository Comparison") {
+		t.Fatalf("terminal output missing header: %s", terminal)
+	}
+
+	jsonData, err := RenderCompareJSON(report)
+	if err != nil {
+		t.Fatalf("RenderCompareJSON failed: %v", err)
+	}
+	if !strings.Contains(string(jsonData), "owner/alpha") {
+		t.Fatalf("JSON output missing repo name: %s", string(jsonData))
+	}
+
+	markdown, err := RenderCompareMarkdown(report)
+	if err != nil {
+		t.Fatalf("RenderCompareMarkdown failed: %v", err)
+	}
+	if !strings.Contains(string(markdown), "# Repository Comparison") {
+		t.Fatalf("markdown output missing title: %s", string(markdown))
+	}
+
+	htmlData, err := RenderCompareHTML(report)
+	if err != nil {
+		t.Fatalf("RenderCompareHTML failed: %v", err)
+	}
+	if !strings.Contains(string(htmlData), "Repo-lyzer comparison report") {
+		t.Fatalf("html output missing title: %s", string(htmlData))
+	}
+}

--- a/internal/output/compare_test.go
+++ b/internal/output/compare_test.go
@@ -75,13 +75,26 @@ func TestRenderCompareOutputs(t *testing.T) {
 	if !strings.Contains(terminal, "Repository Comparison") {
 		t.Fatalf("terminal output missing header: %s", terminal)
 	}
+	lowerTerm := strings.ToLower(terminal)
+	normTerm := strings.ReplaceAll(lowerTerm, " / ", "/")
+	if !strings.Contains(normTerm, "owner/alpha") || !strings.Contains(normTerm, "owner/beta") {
+		t.Fatalf("terminal output missing one of repo names: %s", terminal)
+	}
+	if !strings.Contains(normTerm, strings.ToLower(report.Verdict)) {
+		t.Fatalf("terminal output missing verdict: %s", terminal)
+	}
 
 	jsonData, err := RenderCompareJSON(report)
 	if err != nil {
 		t.Fatalf("RenderCompareJSON failed: %v", err)
 	}
-	if !strings.Contains(string(jsonData), "owner/alpha") {
-		t.Fatalf("JSON output missing repo name: %s", string(jsonData))
+	lowerJSON := strings.ToLower(string(jsonData))
+	normJSON := strings.ReplaceAll(lowerJSON, " / ", "/")
+	if !strings.Contains(normJSON, "owner/alpha") || !strings.Contains(normJSON, "owner/beta") {
+		t.Fatalf("JSON output missing one of repo names: %s", string(jsonData))
+	}
+	if !strings.Contains(normJSON, strings.ToLower(report.Verdict)) {
+		t.Fatalf("JSON output missing verdict: %s", string(jsonData))
 	}
 
 	markdown, err := RenderCompareMarkdown(report)
@@ -91,6 +104,14 @@ func TestRenderCompareOutputs(t *testing.T) {
 	if !strings.Contains(string(markdown), "# Repository Comparison") {
 		t.Fatalf("markdown output missing title: %s", string(markdown))
 	}
+	lowerMD := strings.ToLower(string(markdown))
+	normMD := strings.ReplaceAll(lowerMD, " / ", "/")
+	if !strings.Contains(normMD, "owner/alpha") || !strings.Contains(normMD, "owner/beta") {
+		t.Fatalf("markdown output missing one of repo names: %s", string(markdown))
+	}
+	if !strings.Contains(normMD, strings.ToLower(report.Verdict)) {
+		t.Fatalf("markdown output missing verdict: %s", string(markdown))
+	}
 
 	htmlData, err := RenderCompareHTML(report)
 	if err != nil {
@@ -98,5 +119,13 @@ func TestRenderCompareOutputs(t *testing.T) {
 	}
 	if !strings.Contains(string(htmlData), "Repo-lyzer comparison report") {
 		t.Fatalf("html output missing title: %s", string(htmlData))
+	}
+	lowerHTML := strings.ToLower(string(htmlData))
+	normHTML := strings.ReplaceAll(lowerHTML, " / ", "/")
+	if !strings.Contains(normHTML, "owner/alpha") || !strings.Contains(normHTML, "owner/beta") {
+		t.Fatalf("html output missing one of repo names: %s", string(htmlData))
+	}
+	if !strings.Contains(normHTML, strings.ToLower(report.Verdict)) {
+		t.Fatalf("html output missing verdict: %s", string(htmlData))
 	}
 }

--- a/internal/output/templates/compare.html
+++ b/internal/output/templates/compare.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Repo-lyzer Comparison Report</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f4f7fb;
+      --panel: #ffffff;
+      --panel-alt: #eef4ff;
+      --text: #112033;
+      --muted: #5b6b7f;
+      --border: #d8e0eb;
+      --accent: #0f766e;
+      --accent-2: #2563eb;
+      --good: #16a34a;
+      --warn: #d97706;
+      --bad: #dc2626;
+      --shadow: 0 20px 50px rgba(17, 32, 51, 0.10);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at top left, rgba(37, 99, 235, 0.09), transparent 32%),
+        radial-gradient(circle at top right, rgba(15, 118, 110, 0.08), transparent 28%),
+        linear-gradient(180deg, #f7f9fc 0%, var(--bg) 100%);
+      color: var(--text);
+      line-height: 1.5;
+    }
+
+    .page {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 40px 20px 56px;
+    }
+
+    .hero {
+      background: linear-gradient(135deg, rgba(15,118,110,0.96), rgba(37,99,235,0.94));
+      color: white;
+      border-radius: 28px;
+      padding: 32px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      position: relative;
+    }
+
+    .hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(255,255,255,0.08), transparent 45%);
+      pointer-events: none;
+    }
+
+    .eyebrow {
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-size: 0.74rem;
+      opacity: 0.85;
+      margin-bottom: 8px;
+      position: relative;
+      z-index: 1;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(2rem, 4vw, 3.3rem);
+      line-height: 1.05;
+      position: relative;
+      z-index: 1;
+    }
+
+    .meta {
+      margin-top: 12px;
+      color: rgba(255,255,255,0.86);
+      font-size: 0.98rem;
+      position: relative;
+      z-index: 1;
+    }
+
+    .verdict {
+      margin-top: 18px;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      background: rgba(255,255,255,0.12);
+      border: 1px solid rgba(255,255,255,0.18);
+      border-radius: 999px;
+      position: relative;
+      z-index: 1;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 18px;
+      margin-top: 18px;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 24px;
+      box-shadow: var(--shadow);
+      padding: 24px;
+    }
+
+    .repo-title {
+      margin: 0;
+      font-size: 1.35rem;
+    }
+
+    .repo-desc {
+      margin: 8px 0 0;
+      color: var(--muted);
+      min-height: 1.5em;
+    }
+
+    .pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 7px 10px;
+      border-radius: 999px;
+      background: var(--panel-alt);
+      border: 1px solid rgba(37,99,235,0.14);
+      color: var(--text);
+      font-size: 0.88rem;
+      font-weight: 600;
+    }
+
+    .score {
+      margin-left: auto;
+      padding: 7px 10px;
+      border-radius: 999px;
+      font-size: 0.88rem;
+      font-weight: 700;
+      color: white;
+    }
+
+    .score-good { background: var(--good); }
+    .score-warning { background: var(--warn); }
+    .score-bad { background: var(--bad); }
+
+    h2 {
+      margin: 0 0 14px;
+      font-size: 1.1rem;
+    }
+
+    .metrics {
+      margin-top: 18px;
+      overflow: hidden;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      padding: 14px 12px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      color: var(--muted);
+      font-size: 0.85rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .metric-better {
+      font-weight: 700;
+      color: var(--good);
+    }
+
+    .metric-worse {
+      color: var(--bad);
+    }
+
+    .languages {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 18px;
+      margin-top: 18px;
+    }
+
+    .lang-list {
+      display: grid;
+      gap: 12px;
+    }
+
+    .lang-row {
+      display: grid;
+      gap: 6px;
+    }
+
+    .lang-top {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      font-size: 0.92rem;
+      font-weight: 600;
+    }
+
+    .bar {
+      height: 12px;
+      border-radius: 999px;
+      background: rgba(37,99,235,0.12);
+      overflow: hidden;
+    }
+
+    .bar > span {
+      display: block;
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, var(--accent), var(--accent-2));
+    }
+
+    .footer {
+      margin-top: 18px;
+      color: var(--muted);
+      font-size: 0.88rem;
+      text-align: right;
+    }
+
+    @media (max-width: 900px) {
+      .grid, .languages { grid-template-columns: 1fr; }
+      .page { padding: 18px 14px 36px; }
+      .hero { padding: 24px; border-radius: 22px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="hero">
+      <div class="eyebrow">Repo-lyzer comparison report</div>
+      <h1>{{.Repo1.FullName}} vs {{.Repo2.FullName}}</h1>
+      <div class="meta">Generated {{.GeneratedAt}}</div>
+      <div class="verdict">{{.Verdict}}</div>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <h2 class="repo-title">{{.Repo1.FullName}}</h2>
+        <p class="repo-desc">{{.Repo1.Description}}</p>
+        <div class="pills">
+          <span class="pill">Primary language: {{.Repo1.PrimaryLanguage}}</span>
+          <span class="score {{.Repo1.HealthClass}}">Health {{.Repo1.HealthScore}}</span>
+          <span class="pill">Maturity {{.Repo1.MaturityLevel}} ({{.Repo1.MaturityScore}})</span>
+          <span class="pill">Bus factor {{.Repo1.BusFactor}} ({{.Repo1.BusRisk}})</span>
+        </div>
+      </article>
+
+      <article class="card">
+        <h2 class="repo-title">{{.Repo2.FullName}}</h2>
+        <p class="repo-desc">{{.Repo2.Description}}</p>
+        <div class="pills">
+          <span class="pill">Primary language: {{.Repo2.PrimaryLanguage}}</span>
+          <span class="score {{.Repo2.HealthClass}}">Health {{.Repo2.HealthScore}}</span>
+          <span class="pill">Maturity {{.Repo2.MaturityLevel}} ({{.Repo2.MaturityScore}})</span>
+          <span class="pill">Bus factor {{.Repo2.BusFactor}} ({{.Repo2.BusRisk}})</span>
+        </div>
+      </article>
+    </section>
+
+    <section class="card metrics">
+      <h2>Side-by-side metrics</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th>{{.Repo1.FullName}}</th>
+            <th>{{.Repo2.FullName}}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range .Metrics}}
+          <tr>
+            <td>{{.Label}}</td>
+            <td class="{{.LeftClass}}">{{.Left}}</td>
+            <td class="{{.RightClass}}">{{.Right}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </section>
+
+    <section class="languages">
+      <article class="card">
+        <h2>Language breakdown - {{.Repo1.FullName}}</h2>
+        {{if .Repo1.Languages}}
+        <div class="lang-list">
+          {{range .Repo1.Languages}}
+          <div class="lang-row">
+            <div class="lang-top">
+              <span>{{.Name}}</span>
+              <span>{{.Percentage}}</span>
+            </div>
+            <div class="bar"><span style="width: {{.Width}}%;"></span></div>
+          </div>
+          {{end}}
+        </div>
+        {{else}}
+        <p class="repo-desc">No language data available.</p>
+        {{end}}
+      </article>
+
+      <article class="card">
+        <h2>Language breakdown - {{.Repo2.FullName}}</h2>
+        {{if .Repo2.Languages}}
+        <div class="lang-list">
+          {{range .Repo2.Languages}}
+          <div class="lang-row">
+            <div class="lang-top">
+              <span>{{.Name}}</span>
+              <span>{{.Percentage}}</span>
+            </div>
+            <div class="bar"><span style="width: {{.Width}}%;"></span></div>
+          </div>
+          {{end}}
+        </div>
+        {{else}}
+        <p class="repo-desc">No language data available.</p>
+        {{end}}
+      </article>
+    </section>
+
+    <div class="footer">Generated by Repo-lyzer</div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Adds export support for `repo-lyzer compare` in terminal, JSON, Markdown, and HTML formats, plus `--save` for writing output to a file. The implementation reuses a shared comparison report model, adds an embedded HTML template, and includes focused tests.\n\nValidation: `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compare command can render and export reports in terminal, JSON, Markdown, and HTML, and save reports to disk.
  * Reports present side-by-side metrics, language breakdowns, health/maturity scores, and an overall verdict.

* **Documentation**
  * Command help expanded with examples for format and save options.

* **Tests**
  * Added tests validating report construction and rendering across all formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->