### PR TITLE
feat(ui): integrate FileTreeViewer with app state

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -182,6 +182,20 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ErrorMsg:
 		m.err = error(msg)
 		return m, nil
+
+	case string:
+		// Global string messages from sub-models (dashboard returns "switch_to_tree")
+		if msg == "switch_to_tree" {
+			if len(m.dashboard.data.FileTree) > 0 {
+				m.tree = NewTreeModel(&m.dashboard.data)
+			} else {
+				m.tree = NewTreeModel(nil)
+			}
+			m.tree.width = m.windowWidth
+			m.tree.height = m.windowHeight
+			m.state = stateTree
+			return m, nil
+		}
 	}
 
 	// Delegate to current state's sub-model


### PR DESCRIPTION
## Related Issue

Closes #313

## Summary

This PR integrates the existing FileTreeViewer with the main application state and dashboard shortcut flow.

Previously, pressing `f` from the dashboard emitted a `"switch_to_tree"` message, but the message was not handled in the main application update loop. As a result, the application never initialized the tree model or transitioned to the file tree view.

## Changes Made

- Added handling for the `"switch_to_tree"` message in `MainModel.Update()`
- Initialized `FileTreeViewer` using the current dashboard analysis data
- Added state transition to `stateTree`
- Passed application dimensions to the tree model for proper rendering
- Ensured the File Tree Viewer opens correctly from the dashboard shortcut (`f`)

## Testing

### Before
- Pressing `f` on the dashboard produced no state transition
- FileTreeViewer never opened despite the shortcut being available

### After
- Pressing `f` successfully opens the File Tree Viewer
- Repository file structure is displayed correctly
- Tree model is initialized using the current analysis data
- No regressions observed in dashboard navigation

## Screenshots

<img width="1098" height="840" alt="Screenshot 2026-05-30 110600" src="https://github.com/user-attachments/assets/c009d8ae-f4b4-4a5d-8fa8-69e6b820ed4c" />

<img width="1140" height="809" alt="Screenshot 2026-05-30 110623" src="https://github.com/user-attachments/assets/5172549e-4887-474c-bddc-658474070fe1" />
<img width="1100" height="692" alt="Screenshot 2026-05-30 110641" src="https://github.com/user-attachments/assets/2c01d46e-c495-4eeb-bc32-76e31cbadfe8" />


Attached screenshots demonstrating: FileTreeViewer opening successfully after pressing `f`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now switch to a tree view that displays content hierarchically. The tree view automatically initializes with available data and adjusts to fit the current window dimensions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->