### PR TITLE
fix(github): retry/backoff & rate-limit handling

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -64,58 +64,126 @@ func (c *Client) SetToken(token string) {
 // get performs a GET request to the GitHub API and decodes the JSON response.
 // It handles authentication and provides detailed error messages for rate limiting.
 func (c *Client) get(url string, target interface{}) error {
-	req, err := http.NewRequestWithContext(c.ctx, "GET", url, nil)
-	if err != nil {
-		return err
-	}
+	// Implement retry with exponential backoff and respect rate-limit headers.
+	const maxRetries = 3
 
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("network error: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Handle rate limiting and forbidden states securely
-	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == 429 {
-		remaining := resp.Header.Get("X-RateLimit-Remaining")
-		resetTime := resp.Header.Get("X-RateLimit-Reset")
-
-		if remaining == "0" || resp.StatusCode == 429 {
-			resetUnix, _ := strconv.ParseInt(resetTime, 10, 64)
-			resetAt := time.Unix(resetUnix, 0)
-			waitTime := time.Until(resetAt)
-
-			if c.token == "" {
-				return fmt.Errorf("🔴 Rate limit exceeded! Resets in %s\n"+
-					"Tip: Set GITHUB_TOKEN env variable for 5000 requests/hour (vs 60 unauthenticated)",
-					formatDuration(waitTime))
-			}
-			return fmt.Errorf("🔴 Rate limit exceeded! Resets in %s", formatDuration(waitTime))
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(c.ctx, "GET", url, nil)
+		if err != nil {
+			return err
 		}
 
-		// Fallback protective validation gate for other 403 scenarios
-		return fmt.Errorf("access forbidden (Status 403): the request was rejected by GitHub API or requires extended permissions")
+		req.Header.Set("Accept", "application/vnd.github+json")
+		if c.token != "" {
+			req.Header.Set("Authorization", "Bearer "+c.token)
+		}
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("network error: %w", err)
+			// Retry on transient network errors
+			if attempt == maxRetries {
+				return lastErr
+			}
+			backoff := time.Duration(1<<attempt) * time.Second
+			select {
+			case <-time.After(backoff):
+				continue
+			case <-c.ctx.Done():
+				return c.ctx.Err()
+			}
+		}
+
+		// Ensure body closed on retry or error branches
+		if resp == nil {
+			lastErr = fmt.Errorf("empty response")
+			if attempt == maxRetries {
+				return lastErr
+			}
+			continue
+		}
+
+		// Handle rate limiting: wait until reset and retry
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == 429 {
+			remaining := resp.Header.Get("X-RateLimit-Remaining")
+			resetTime := resp.Header.Get("X-RateLimit-Reset")
+
+			if remaining == "0" || resp.StatusCode == 429 {
+				resetUnix, _ := strconv.ParseInt(resetTime, 10, 64)
+				resetAt := time.Unix(resetUnix, 0)
+				waitTime := time.Until(resetAt)
+				if waitTime < 0 {
+					waitTime = time.Second
+				}
+
+				resp.Body.Close()
+				// If unauthenticated, return informative error after waiting once
+				if c.token == "" {
+					select {
+					case <-time.After(waitTime + time.Second):
+						return fmt.Errorf("rate limit exceeded and no token configured; consider setting GITHUB_TOKEN")
+					case <-c.ctx.Done():
+						return c.ctx.Err()
+					}
+				}
+
+				// Authenticated: wait and retry
+				select {
+				case <-time.After(waitTime + time.Second):
+					continue
+				case <-c.ctx.Done():
+					return c.ctx.Err()
+				}
+			}
+
+			resp.Body.Close()
+			return fmt.Errorf("access forbidden (Status 403): the request was rejected by GitHub API or requires extended permissions")
+		}
+
+		// Not found
+		if resp.StatusCode == http.StatusNotFound {
+			resp.Body.Close()
+			return fmt.Errorf("repository not found or inaccessible — it may be private or you may not have permission")
+		}
+
+		// Unauthorized
+		if resp.StatusCode == http.StatusUnauthorized {
+			resp.Body.Close()
+			return fmt.Errorf("authentication failed (check your GITHUB_TOKEN)")
+		}
+
+		// Retry on 5xx
+		if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
+			resp.Body.Close()
+			if attempt == maxRetries {
+				return fmt.Errorf("GitHub server error: %s", resp.Status)
+			}
+			backoff := time.Duration(1<<attempt) * time.Second
+			select {
+			case <-time.After(backoff):
+				continue
+			case <-c.ctx.Done():
+				return c.ctx.Err()
+			}
+		}
+
+		// Non-OK responses handled above, so decode on success
+		if resp.StatusCode != http.StatusOK {
+			errMsg := fmt.Errorf("GitHub API error: %s", resp.Status)
+			resp.Body.Close()
+			return errMsg
+		}
+
+		// Success
+		defer resp.Body.Close()
+		return json.NewDecoder(resp.Body).Decode(target)
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("repository not found or inaccessible — it may be private or you may not have permission")
+	if lastErr != nil {
+		return lastErr
 	}
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("authentication failed (check your GITHUB_TOKEN)")
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("GitHub API error: %s", resp.Status)
-	}
-
-	return json.NewDecoder(resp.Body).Decode(target)
+	return fmt.Errorf("request failed: %s", url)
 }
 
 // formatDuration formats a duration in a human-readable way

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,94 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Test that transient 5xx errors are retried and eventual success is returned
+func TestGet_RetriesOnServerError(t *testing.T) {
+	var calls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n <= 2 {
+			// first two calls: server error
+			http.Error(w, "temporary server error", http.StatusInternalServerError)
+			return
+		}
+
+		// third call: success with user JSON
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"login": "alice", "name": "Alice"})
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	// use server's client to ensure same transport
+	c.http = srv.Client()
+	c.SetContext(context.Background())
+
+	var u User
+	if err := c.get(srv.URL+"/user", &u); err != nil {
+		t.Fatalf("expected success after retries, got err: %v", err)
+	}
+	if u.Login != "alice" {
+		t.Fatalf("expected login alice, got %q", u.Login)
+	}
+	if atomic.LoadInt32(&calls) < 3 {
+		t.Fatalf("expected at least 3 calls, got %d", calls)
+	}
+}
+
+// Test that when GitHub rate-limits (429) the client waits until reset and retries
+func TestGet_WaitsOnRateLimit(t *testing.T) {
+	var calls int32
+
+	// first call: respond with 429 and X-RateLimit-Reset in ~1s
+	// second call: return success
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			resetAt := time.Now().Add(1 * time.Second).Unix()
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt, 10))
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"login": "ratelimited", "name": "Rate"})
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.http = srv.Client()
+	// ensure client is treated as authenticated so it will wait and retry
+	c.SetToken("fake-token")
+	// give context enough time for wait+1s buffer used in client
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	c.SetContext(ctx)
+
+	var u User
+	start := time.Now()
+	if err := c.get(srv.URL+"/user", &u); err != nil {
+		t.Fatalf("expected success after rate-limit wait, got err: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 1*time.Second {
+		t.Fatalf("expected to wait at least ~1s for rate-limit reset, waited %v", elapsed)
+	}
+	if u.Login != "ratelimited" {
+		t.Fatalf("expected login ratelimited, got %q", u.Login)
+	}
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("expected at least 2 calls, got %d", calls)
+	}
+}


### PR DESCRIPTION

## Summary
Add automatic retries with exponential backoff for transient network/5xx errors and wait-for-reset handling for GitHub rate limits to avoid mid-scan failures.

## Files Changed

- `internal/github/client.go` , retry/backoff + rate-limit wait
- `internal/github/client_test.go` , tests for 5xx retry and 429 wait/retry

## Run Tests

```bash
cd Repo-lyzer
go test ./internal/github -run TestGet -v
```

## Notes

Retry parameters are fixed for now and can be made configurable later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of GitHub API requests with automatic retry logic for transient network failures.
  * Enhanced rate limit handling with intelligent wait-and-retry behavior for authenticated requests.
  * Better error reporting and response handling for failed requests.

* **Tests**
  * Added integration tests for retry behavior and rate limit handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->