### PR TITLE
fix: add user-friendly validation for missing argument in summary command

### DIFF
--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -43,6 +43,11 @@ Examples:
 			fmt.Println("Usage:   repo-lyzer summary <repository>")
 			fmt.Println("Example: repo-lyzer summary golang/go")
 			return fmt.Errorf("repository name required")
+		} else if len(args) > 1 {
+			fmt.Println("Error: too many arguments provided.")
+			fmt.Println("Usage:   repo-lyzer summary <repository>")
+			fmt.Println("Example: repo-lyzer summary golang/go")
+			return fmt.Errorf("too many arguments: expected 1, got %d", len(args))
 		}
 
 		// Validate the repository URL format

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -37,8 +37,14 @@ Examples:
   repo-lyzer summary facebook/react
   repo-lyzer summary vuejs/vue
   repo-lyzer summary angular/angular`,
-	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			fmt.Println("Error: please provide a repository name to analyze.")
+			fmt.Println("Usage:   repo-lyzer summary <repository>")
+			fmt.Println("Example: repo-lyzer summary golang/go")
+			return fmt.Errorf("repository name required")
+		}
+
 		// Validate the repository URL format
 		owner, repo, err := validateRepoURL(args[0])
 		if err != nil {


### PR DESCRIPTION
## Description
Adds user-friendly validation for the `summary` command when no repository argument is provided.

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #330

## What's Changed
- Removed `cobra.ExactArgs(1)` from `summaryCmd`
- Added `len(args) == 0` check at the start of `RunE`
- Returns a clear, actionable error message with usage and example

**Before:**
accepts 1 arg(s), received 0

**After:**
Error: please provide a repository name to analyze.
Usage:   repo-lyzer summary <repository>
Example: repo-lyzer summary golang/go

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #330

## What's Changed
- Removed `cobra.ExactArgs(1)` from `summaryCmd`
- Added `len(args) == 0` check at the start of `RunE`
- Returns a clear error message with usage and example when no repository argument is provided
- Only `cmd/summary.go` was modified — no other files touched

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings generated
- [x] Only `cmd/summary.go` was modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument validation for the summary command: clearer error messages, usage information, and examples when the required repository name is missing.
  * Added explicit handling and user-facing error/usage guidance when too many arguments are provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->