### PR TITLE
fix(temporal): compute final summary metrics from indicators

### DIFF
--- a/internal/temporal/coordinator.go
+++ b/internal/temporal/coordinator.go
@@ -2,6 +2,7 @@ package temporal
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/agnivo988/Repo-lyzer/internal/evolution"
@@ -234,9 +235,9 @@ func (c *Coordinator) Finalize() *AnalysisResult {
 	}
 
 	// Compute summary metrics
-	result.HealthScore = 75 // TODO: Calculate from actual data
-	result.HealthTrend = "stable"
-	result.OverallRiskLevel = "medium"
+	result.HealthScore = c.computeHealthScore()
+	result.HealthTrend = c.computeHealthTrend()
+	result.OverallRiskLevel = c.computeOverallRiskLevel()
 	result.CriticalIssues = make([]string, 0)
 
 	// Identify critical issues from findings
@@ -247,6 +248,138 @@ func (c *Coordinator) Finalize() *AnalysisResult {
 	}
 
 	return result
+}
+
+func (c *Coordinator) computeHealthScore() int {
+	if c.Timeline == nil {
+		return 50
+	}
+
+	score := 100
+
+	for _, risk := range c.RiskIndicators {
+		switch strings.ToLower(risk.Severity) {
+		case "critical":
+			score -= 30
+		case "high":
+			score -= 20
+		case "medium":
+			score -= 10
+		case "low":
+			score -= 5
+		default:
+			score -= 2
+		}
+	}
+
+	for _, drift := range c.DriftIndicators {
+		switch strings.ToLower(drift.Severity) {
+		case "high":
+			score -= 8
+		case "medium":
+			score -= 4
+		case "low":
+			score -= 2
+		}
+	}
+
+	if c.HealthForecast != nil {
+		switch strings.ToLower(c.HealthForecast.Trend) {
+		case "improving":
+			score += 8
+		case "degrading":
+			score -= 10
+		}
+	}
+
+	if score < 0 {
+		return 0
+	}
+	if score > 100 {
+		return 100
+	}
+	return score
+}
+
+func (c *Coordinator) computeHealthTrend() string {
+	if c.HealthForecast != nil {
+		switch strings.ToLower(c.HealthForecast.Trend) {
+		case "improving":
+			return "improving"
+		case "degrading":
+			return "declining"
+		case "stable":
+			return "stable"
+		}
+	}
+
+	var improvingSignals, worseningSignals int
+	for _, risk := range c.RiskIndicators {
+		switch strings.ToLower(risk.Trajectory) {
+		case "improving":
+			improvingSignals++
+		case "worsening":
+			worseningSignals++
+		}
+	}
+
+	for _, drift := range c.DriftIndicators {
+		switch strings.ToLower(drift.Direction) {
+		case "decreasing":
+			improvingSignals++
+		case "increasing":
+			worseningSignals++
+		}
+	}
+
+	if worseningSignals > improvingSignals {
+		return "declining"
+	}
+	if improvingSignals > worseningSignals {
+		return "improving"
+	}
+
+	return "stable"
+}
+
+func (c *Coordinator) computeOverallRiskLevel() string {
+	riskLevel := "low"
+
+	for _, risk := range c.RiskIndicators {
+		riskLevel = maxRiskLevel(riskLevel, risk.Severity)
+	}
+
+	for _, drift := range c.DriftIndicators {
+		riskLevel = maxRiskLevel(riskLevel, drift.Severity)
+	}
+
+	if c.HealthForecast != nil {
+		riskLevel = maxRiskLevel(riskLevel, c.HealthForecast.RiskLevel)
+	}
+
+	return riskLevel
+}
+
+func maxRiskLevel(current, candidate string) string {
+	rank := map[string]int{
+		"low":      1,
+		"medium":   2,
+		"high":     3,
+		"critical": 4,
+	}
+
+	currentRank, currentOk := rank[strings.ToLower(current)]
+	candidateRank, candidateOk := rank[strings.ToLower(candidate)]
+	if !candidateOk {
+		return current
+	}
+	if !currentOk {
+		return candidate
+	}
+	if candidateRank <= currentRank {
+		return current
+	}
+	return candidate
 }
 
 // FullAnalysisPipeline runs the complete temporal analysis workflow.

--- a/internal/temporal/coordinator_test.go
+++ b/internal/temporal/coordinator_test.go
@@ -1,0 +1,102 @@
+package temporal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agnivo988/Repo-lyzer/internal/evolution"
+	"github.com/agnivo988/Repo-lyzer/internal/predictive"
+)
+
+func TestFinalize_UsesComputedSummaryMetrics(t *testing.T) {
+	coordinator := NewCoordinator("owner", "repo")
+	coordinator.Timeline.AddSnapshot(NewSnapshot(time.Now(), nil))
+
+	coordinator.RiskIndicators = []evolution.RiskIndicator{
+		{
+			Name:       "dependency drift",
+			Severity:   "high",
+			Trajectory: "worsening",
+		},
+	}
+	coordinator.DriftIndicators = []evolution.DriftIndicator{
+		{
+			SubsystemID: "core",
+			Severity:    "medium",
+			Direction:   "increasing",
+		},
+	}
+	coordinator.HealthForecast = &predictive.ForecastResult{
+		Trend:     "improving",
+		RiskLevel: "medium",
+	}
+
+	result := coordinator.Finalize()
+
+	if result.HealthScore != 74 {
+		t.Fatalf("HealthScore = %d, want 74", result.HealthScore)
+	}
+	if result.HealthTrend != "improving" {
+		t.Fatalf("HealthTrend = %q, want improving", result.HealthTrend)
+	}
+	if result.OverallRiskLevel != "high" {
+		t.Fatalf("OverallRiskLevel = %q, want high", result.OverallRiskLevel)
+	}
+}
+
+func TestFinalize_WithNoForecastFallsBackToSignalCounts(t *testing.T) {
+	coordinator := NewCoordinator("owner", "repo")
+	coordinator.Timeline.AddSnapshot(NewSnapshot(time.Now(), nil))
+
+	coordinator.RiskIndicators = []evolution.RiskIndicator{
+		{
+			Name:       "activity drop",
+			Severity:   "medium",
+			Trajectory: "improving",
+		},
+	}
+	coordinator.DriftIndicators = []evolution.DriftIndicator{
+		{
+			SubsystemID: "ui",
+			Severity:    "low",
+			Direction:   "decreasing",
+		},
+	}
+
+	result := coordinator.Finalize()
+
+	if result.HealthTrend != "improving" {
+		t.Fatalf("HealthTrend = %q, want improving", result.HealthTrend)
+	}
+	if result.HealthScore != 86 {
+		t.Fatalf("HealthScore = %d, want 86", result.HealthScore)
+	}
+	if result.OverallRiskLevel != "medium" {
+		t.Fatalf("OverallRiskLevel = %q, want medium", result.OverallRiskLevel)
+	}
+}
+
+func TestFinalize_CollectsCriticalIssues(t *testing.T) {
+	coordinator := NewCoordinator("owner", "repo")
+	coordinator.Timeline.AddSnapshot(NewSnapshot(time.Now(), nil))
+
+	coordinator.RiskIndicators = []evolution.RiskIndicator{
+		{
+			Name:     "critical issue",
+			Severity: "critical",
+		},
+		{
+			Name:     "low issue",
+			Severity: "low",
+		},
+	}
+
+	result := coordinator.Finalize()
+
+	if len(result.CriticalIssues) != 1 {
+		t.Fatalf("CriticalIssues len = %d, want 1", len(result.CriticalIssues))
+	}
+	if result.CriticalIssues[0] != "critical issue" {
+		t.Fatalf("CriticalIssues[0] = %q, want %q", result.CriticalIssues[0], "critical issue")
+	}
+}

--- a/internal/temporal/coordinator_test.go
+++ b/internal/temporal/coordinator_test.go
@@ -33,8 +33,8 @@ func TestFinalize_UsesComputedSummaryMetrics(t *testing.T) {
 
 	result := coordinator.Finalize()
 
-	if result.HealthScore != 74 {
-		t.Fatalf("HealthScore = %d, want 74", result.HealthScore)
+	if result.HealthScore != 84 {
+		t.Fatalf("HealthScore = %d, want 84", result.HealthScore)
 	}
 	if result.HealthTrend != "improving" {
 		t.Fatalf("HealthTrend = %q, want improving", result.HealthTrend)
@@ -68,8 +68,8 @@ func TestFinalize_WithNoForecastFallsBackToSignalCounts(t *testing.T) {
 	if result.HealthTrend != "improving" {
 		t.Fatalf("HealthTrend = %q, want improving", result.HealthTrend)
 	}
-	if result.HealthScore != 86 {
-		t.Fatalf("HealthScore = %d, want 86", result.HealthScore)
+	if result.HealthScore != 88 {
+		t.Fatalf("HealthScore = %d, want 88", result.HealthScore)
 	}
 	if result.OverallRiskLevel != "medium" {
 		t.Fatalf("OverallRiskLevel = %q, want medium", result.OverallRiskLevel)


### PR DESCRIPTION
## What
This PR replaces the hardcoded temporal summary placeholders in `Coordinator.Finalize()` with computed values derived from risk/drift indicators and forecast outputs.

## How
- Added `computeHealthScore()`, `computeHealthTrend()`, and `computeOverallRiskLevel()` in `internal/temporal/coordinator.go`.
- Made the finalize flow use these computed values instead of fixed constants.
- Added small helper `maxRiskLevel()` for deterministic aggregate risk.
- Added focused tests for summary computation behavior in `internal/temporal/coordinator_test.go`.

## Testing
- Could not execute package tests because the environment does not have the Go toolchain (`go` is unavailable).

## Risks / Notes
- This package contains other MVP-level placeholder paths, so this change only covers summary metric derivation and keeps existing behavior in unimplemented modules unchanged.
- No behavioral changes are expected outside temporal summary outputs.

Closes #362
