### PR TITLE
fix(analyzer): decode hotspot file content before scoring

### DIFF
--- a/internal/analyzer/hotspots.go
+++ b/internal/analyzer/hotspots.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"encoding/base64"
 	"math"
 	"sort"
 	"strings"
@@ -101,7 +102,12 @@ func AnalyzeHotspots(
 
 			content, err := client.GetFileContent(repo.Owner.Login, repo.Name, hotspot.FilePath)
 			if err == nil {
-				hotspot.Complexity = calculateComplexity(content, hotspot.FilePath)
+				complexity, err := calculateComplexityFromGitHubContent(content, hotspot.FilePath)
+				if err != nil {
+					hotspot.Reason = "Unable to decode file content"
+					return
+				}
+				hotspot.Complexity = complexity
 
 				// Update score with actual complexity
 				// Map complexity 1-50 to 0-100
@@ -175,6 +181,15 @@ func analyzeChurn(commits []github.Commit, repo *github.Repo, client *github.Cli
 	wg.Wait()
 
 	return churnMap
+}
+
+func calculateComplexityFromGitHubContent(content, filename string) (int, error) {
+	decoded, err := base64.StdEncoding.DecodeString(content)
+	if err != nil {
+		return 0, err
+	}
+
+	return calculateComplexity(string(decoded), filename), nil
 }
 
 func calculateComplexity(content, filename string) int {

--- a/internal/analyzer/hotspots.go
+++ b/internal/analyzer/hotspots.go
@@ -184,7 +184,8 @@ func analyzeChurn(commits []github.Commit, repo *github.Repo, client *github.Cli
 }
 
 func calculateComplexityFromGitHubContent(content, filename string) (int, error) {
-	decoded, err := base64.StdEncoding.DecodeString(content)
+	normalized := strings.NewReplacer("\n", "", "\r", "").Replace(content)
+	decoded, err := base64.StdEncoding.DecodeString(normalized)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/analyzer/hotspots_test.go
+++ b/internal/analyzer/hotspots_test.go
@@ -16,8 +16,9 @@ func TestCalculateComplexityFromGitHubContentDecodesBeforeScanning(t *testing.T)
   }
 }`
 	encoded := base64.StdEncoding.EncodeToString([]byte(source))
+	wrapped := encoded[:24] + "\n" + encoded[24:48] + "\r\n" + encoded[48:]
 
-	got, err := calculateComplexityFromGitHubContent(encoded, "risk.js")
+	got, err := calculateComplexityFromGitHubContent(wrapped, "risk.js")
 	if err != nil {
 		t.Fatalf("expected encoded GitHub content to decode: %v", err)
 	}

--- a/internal/analyzer/hotspots_test.go
+++ b/internal/analyzer/hotspots_test.go
@@ -1,0 +1,40 @@
+package analyzer
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestCalculateComplexityFromGitHubContentDecodesBeforeScanning(t *testing.T) {
+	source := `function risky(value) {
+  if (value) {
+    for (let i = 0; i < 3; i++) {
+      if (i && value.ok) {
+        return value.ready ? 1 : 0
+      }
+    }
+  }
+}`
+	encoded := base64.StdEncoding.EncodeToString([]byte(source))
+
+	got, err := calculateComplexityFromGitHubContent(encoded, "risk.js")
+	if err != nil {
+		t.Fatalf("expected encoded GitHub content to decode: %v", err)
+	}
+
+	want := calculateComplexity(source, "risk.js")
+	if got != want {
+		t.Fatalf("expected decoded source complexity %d, got %d", want, got)
+	}
+
+	encodedOnly := calculateComplexity(encoded, "risk.js")
+	if got <= encodedOnly {
+		t.Fatalf("expected decoded complexity %d to exceed encoded-text complexity %d", got, encodedOnly)
+	}
+}
+
+func TestCalculateComplexityFromGitHubContentRejectsInvalidBase64(t *testing.T) {
+	if _, err := calculateComplexityFromGitHubContent("not valid base64", "broken.go"); err == nil {
+		t.Fatal("expected invalid base64 content to return an error")
+	}
+}


### PR DESCRIPTION
## What
Fixes hotspot complexity scoring so GitHub file contents are decoded before the analyzer scans source tokens. This prevents base64 text from collapsing complex files to near-baseline complexity and producing misleading hotspot rankings. Closes #364.

## How
Added a small decoded-content helper for hotspot complexity calculation, wired `AnalyzeHotspots` through it, and marks undecodable content explicitly instead of scoring encoded text as source code.

## Testing
Ran `gofmt` with the local temp Go toolchain, `git diff --check`, `go test ./internal/analyzer`, and `go test ./... -timeout=2m`. Added regression coverage proving encoded GitHub content is decoded before complexity scanning and invalid base64 is rejected.

## Risks / Notes
No API or CLI contract changes. The only behavior change is that hotspot complexity now reflects decoded source content; malformed file content no longer produces a fake low complexity score.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of complexity analysis for GitHub files by decoding base64-encoded file content before computing complexity; files that cannot be decoded are flagged and excluded from scoring.

* **Tests**
  * Added tests verifying base64 decoding is applied prior to analysis and that invalid base64 input is handled with an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->