### PR TITLE
fix: decode base64 file content before calculating hotspot complexity (issue #366)

### DIFF
--- a/internal/analyzer/hotspots.go
+++ b/internal/analyzer/hotspots.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"encoding/base64"
 	"math"
 	"sort"
 	"strings"
@@ -99,25 +100,30 @@ func AnalyzeHotspots(
 			defer wg.Done()
 			hotspot := &topCandidates[idx]
 
-			content, err := client.GetFileContent(repo.Owner.Login, repo.Name, hotspot.FilePath)
-			if err == nil {
-				hotspot.Complexity = calculateComplexity(content, hotspot.FilePath)
-
-				// Update score with actual complexity
-				// Map complexity 1-50 to 0-100
-				compScore := hotspot.Complexity * 2
-				if compScore > 100 {
-					compScore = 100
-				}
-
-				// Refine total score
-				// Churn: 40%, Size: 20%, Complexity: 40%
-				hotspot.Score = (hotspot.ChurnScore * 40 / 100) +
-					(hotspot.SizeScore * 20 / 100) +
-					(compScore * 40 / 100)
-
-				hotspot.Reason = generateReason(hotspot)
+			raw, err := client.GetFileContent(repo.Owner.Login, repo.Name, hotspot.FilePath)
+			if err != nil {
+				return
 			}
+			decoded, err := base64.StdEncoding.DecodeString(raw)
+			if err != nil {
+				return
+			}
+			hotspot.Complexity = calculateComplexity(string(decoded), hotspot.FilePath)
+
+			// Update score with actual complexity
+			// Map complexity 1-50 to 0-100
+			compScore := hotspot.Complexity * 2
+			if compScore > 100 {
+				compScore = 100
+			}
+
+			// Refine total score
+			// Churn: 40%, Size: 20%, Complexity: 40%
+			hotspot.Score = (hotspot.ChurnScore * 40 / 100) +
+				(hotspot.SizeScore * 20 / 100) +
+				(compScore * 40 / 100)
+
+			hotspot.Reason = generateReason(hotspot)
 		}(i)
 	}
 	wg.Wait()


### PR DESCRIPTION
## Problem
`AnalyzeHotspots` in `internal/analyzer/hotspots.go` called `client.GetFileContent` which returns GitHub's base64-encoded payload with newlines stripped. This raw base64 string was passed directly to `calculateComplexity`, which splits on `\n` and searches for `if`, `for`, `switch` keywords. As a result, complexity scores were meaningless for every file.

## Fix
Added `base64.StdEncoding.DecodeString` after every `GetFileContent` call before passing content to `calculateComplexity`. On fetch or decode error, the goroutine returns early and skips the file without crashing.

## Changes
- Added `encoding/base64` import to `internal/analyzer/hotspots.go`
- Decode raw base64 response before calling `calculateComplexity`
- Early return on fetch or decode error — no panic, file is skipped cleanly

## Verification
`go build ./...` passes with zero errors.

Closes #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotspot complexity analysis by correctly processing file content during assessment.
  * Strengthened error handling in complexity calculations to prevent incomplete or inaccurate analysis results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agnivo988/Repo-lyzer/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->