### PR TITLE
fix: use repo default branch in file viewer URLs instead of hardcoded "main" (issue #370)

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -689,6 +689,9 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					repoName = m.dashboard.data.Repo.FullName
 				}
 				m.fileEdit = NewFileEditModel(m.tree.SelectedPath, repoName)
+				if m.dashboard.data.Repo != nil {
+					m.fileEdit.branch = m.dashboard.data.Repo.DefaultBranch
+				}
 
 				// Check ownership
 				isOwner := m.checkOwnership()

--- a/internal/ui/file_edit.go
+++ b/internal/ui/file_edit.go
@@ -19,6 +19,7 @@ type FileEditModel struct {
 	filePath  string
 	repoOwner string
 	repoName  string
+	branch    string
 	isOwner   bool
 	width     int
 	height    int
@@ -175,7 +176,7 @@ func getDesktopPath() string {
 // openInBrowser opens the file on GitHub in the default browser
 func (m FileEditModel) openInBrowser() tea.Cmd {
 	return func() tea.Msg {
-		githubURL, err := buildBlobURL("github.com", m.repoOwner, m.repoName, m.filePath)
+		githubURL, err := m.buildBlobURL("github.com")
 		if err != nil {
 			return openResultMsg{err}
 		}
@@ -189,7 +190,7 @@ func (m FileEditModel) openInBrowser() tea.Cmd {
 func (m FileEditModel) openInVSCode() tea.Cmd {
 	return func() tea.Msg {
 		// Use vscode.dev to open the file in browser-based VS Code
-		vscodeURL, err := buildVSCodeBlobURL(m.repoOwner, m.repoName, m.filePath)
+		vscodeURL, err := m.buildVSCodeBlobURL()
 		if err != nil {
 			return openResultMsg{err}
 		}
@@ -200,38 +201,48 @@ func (m FileEditModel) openInVSCode() tea.Cmd {
 }
 
 // buildBlobURL creates a safe GitHub blob URL for a repository file.
-func buildBlobURL(host, owner, repo, filePath string) (string, error) {
-	owner = strings.TrimSpace(owner)
-	repo = strings.TrimSpace(repo)
+func (m FileEditModel) buildBlobURL(host string) (string, error) {
+	owner := strings.TrimSpace(m.repoOwner)
+	repo := strings.TrimSpace(m.repoName)
 	if owner == "" || repo == "" {
 		return "", fmt.Errorf("invalid repository reference")
 	}
 
-	safePath, err := sanitizeRepoPath(filePath)
+	safePath, err := sanitizeRepoPath(m.filePath)
 	if err != nil {
 		return "", err
 	}
 
+	branch := m.branch
+	if branch == "" {
+		branch = "main"
+	}
+
 	base := &url.URL{Scheme: "https", Host: host}
-	base.Path = path.Join(owner, repo, "blob", "main", safePath)
+	base.Path = path.Join(owner, repo, "blob", branch, safePath)
 	return base.String(), nil
 }
 
 // buildVSCodeBlobURL creates a safe vscode.dev blob URL for a repository file.
-func buildVSCodeBlobURL(owner, repo, filePath string) (string, error) {
-	owner = strings.TrimSpace(owner)
-	repo = strings.TrimSpace(repo)
+func (m FileEditModel) buildVSCodeBlobURL() (string, error) {
+	owner := strings.TrimSpace(m.repoOwner)
+	repo := strings.TrimSpace(m.repoName)
 	if owner == "" || repo == "" {
 		return "", fmt.Errorf("invalid repository reference")
 	}
 
-	safePath, err := sanitizeRepoPath(filePath)
+	safePath, err := sanitizeRepoPath(m.filePath)
 	if err != nil {
 		return "", err
 	}
 
+	branch := m.branch
+	if branch == "" {
+		branch = "main"
+	}
+
 	base := &url.URL{Scheme: "https", Host: "vscode.dev"}
-	base.Path = path.Join("github", owner, repo, "blob", "main", safePath)
+	base.Path = path.Join("github", owner, repo, "blob", branch, safePath)
 	return base.String(), nil
 }
 

--- a/internal/ui/file_edit_security_test.go
+++ b/internal/ui/file_edit_security_test.go
@@ -8,7 +8,8 @@ import (
 func TestBuildBlobURL_EscapesUntrustedPathSegments(t *testing.T) {
 	t.Parallel()
 
-	got, err := buildBlobURL("github.com", "owner", "repo", "/dir/a&b?.go")
+	m := FileEditModel{repoOwner: "owner", repoName: "repo", filePath: "/dir/a&b?.go", branch: "main"}
+	got, err := m.buildBlobURL("github.com")
 	if err != nil {
 		t.Fatalf("buildBlobURL returned error: %v", err)
 	}
@@ -22,7 +23,8 @@ func TestBuildBlobURL_EscapesUntrustedPathSegments(t *testing.T) {
 func TestBuildVSCodeBlobURL_EscapesPathAndUsesVSCodeHost(t *testing.T) {
 	t.Parallel()
 
-	got, err := buildVSCodeBlobURL("owner", "repo", "/folder/name with spaces.ts")
+	m := FileEditModel{repoOwner: "owner", repoName: "repo", filePath: "/folder/name with spaces.ts", branch: "main"}
+	got, err := m.buildVSCodeBlobURL()
 	if err != nil {
 		t.Fatalf("buildVSCodeBlobURL returned error: %v", err)
 	}
@@ -53,7 +55,8 @@ func TestBuildBlobURL_RejectsInvalidInputs(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := buildBlobURL(tt.host, tt.owner, tt.repo, tt.filePath)
+			m := FileEditModel{repoOwner: tt.owner, repoName: tt.repo, filePath: tt.filePath, branch: "main"}
+			_, err := m.buildBlobURL(tt.host)
 			if err == nil {
 				t.Fatalf("expected error for case %q", tt.name)
 			}


### PR DESCRIPTION
## Problem
`buildBlobURL` and `buildVSCodeBlobURL` in `internal/ui/file_edit.go` hardcoded `"main"` as the branch segment in generated URLs. Repositories using `master`, `develop`, or any other default branch produced broken browser and VS Code links.

## Fix
- Added `branch string` field to `FileEditModel`
- Converted `buildBlobURL` and `buildVSCodeBlobURL` to use `m.branch` with `"main"` as fallback when empty
- In `app.go`, set `m.fileEdit.branch` from `m.dashboard.data.Repo.DefaultBranch` after `NewFileEditModel`

## Changes
- `internal/ui/file_edit.go` — added `branch` field, updated URL builder methods
- `internal/ui/app.go` — pass `DefaultBranch` from analysis result into `FileEditModel`

## Verification
`go build ./...` passes with zero errors.

Closes #370