### PR TITLE
fix: resolve local cache namespace collision between analyze and monitor

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -136,7 +136,9 @@ func getCacheDir() (string, error) {
 
 // repoToFilename converts repo name to safe filename
 func repoToFilename(repoName string) string {
-	return strings.ReplaceAll(repoName, "/", "_") + ".json"
+	name := strings.ReplaceAll(repoName, "/", "_")
+	name = strings.ReplaceAll(name, ":", "_")
+	return name + ".json"
 }
 
 // loadIndex loads the cache index from disk

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -225,6 +225,8 @@ func TestRepoToFilename(t *testing.T) {
 		{"owner/repo", "owner_repo.json"},
 		{"user/my-project", "user_my-project.json"},
 		{"org/repo.name", "org_repo.name.json"},
+		{"analysis:owner/repo", "analysis_owner_repo.json"},
+		{"monitor:owner/repo", "monitor_owner_repo.json"},
 	}
 
 	for _, tt := range tests {

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -310,7 +310,7 @@ func (m *Monitor) loadState() {
 	defer m.stateMutex.Unlock()
 
 	key := fmt.Sprintf("%s/%s", m.owner, m.repo)
-	entry, found := m.cache.Get(key)
+	entry, found := m.cache.Get("monitor:" + key)
 	if !found || entry == nil || len(entry.Analysis) == 0 {
 		return
 	}
@@ -351,7 +351,7 @@ func (m *Monitor) saveState() {
 		stateCopy.Repo = m.repo
 	}
 
-	if err := m.cache.SetWithTTL(key, stateCopy, monitorStateTTL); err != nil {
+	if err := m.cache.SetWithTTL("monitor:"+key, stateCopy, monitorStateTTL); err != nil {
 		log.Printf("Failed to persist monitoring state for %s: %v", key, err)
 	}
 }

--- a/internal/monitor/monitor_state_test.go
+++ b/internal/monitor/monitor_state_test.go
@@ -94,7 +94,7 @@ func TestMonitorState_LoadState_InvalidCachePayload(t *testing.T) {
 		t.Fatalf("NewCache() error = %v", err)
 	}
 
-	if err := c.Set("octocat/hello-world", "invalid-state"); err != nil {
+	if err := c.Set("monitor:octocat/hello-world", "invalid-state"); err != nil {
 		t.Fatalf("Set() error = %v", err)
 	}
 
@@ -125,7 +125,7 @@ func TestMonitorState_LoadState_FillsMissingIdentity(t *testing.T) {
 		t.Fatalf("NewCache() error = %v", err)
 	}
 
-	if err := c.Set("octocat/hello-world", MonitorState{LastCommitSHA: "xyz"}); err != nil {
+	if err := c.Set("monitor:octocat/hello-world", MonitorState{LastCommitSHA: "xyz"}); err != nil {
 		t.Fatalf("Set() error = %v", err)
 	}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -837,7 +837,7 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 
 		// Check cache first
 		if m.cache != nil {
-			if entry, found := m.cache.Get(repoName); found {
+			if entry, found := m.cache.Get("analysis:" + repoName); found {
 				// Unmarshal cached analysis
 				var result AnalysisResult
 				if err := json.Unmarshal(entry.Analysis, &result); err == nil {
@@ -902,7 +902,7 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 		// Compare with cached incremental metadata
 		changedFiles := []string{}
 
-		if entry, found := m.cache.Get(repoName); found {
+		if entry, found := m.cache.Get("analysis:" + repoName); found {
 			if entry.IncrementalMetadata != nil {
 
 				for path, hash := range currentHashes {
@@ -1054,7 +1054,7 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 
 		// Save to cache
 		if m.cache != nil {
-			m.cache.Set(repoName, result)
+			m.cache.Set("analysis:"+repoName, result)
 		}
 
 		// Add success notification


### PR DESCRIPTION
### Description
This PR resolves issue #333. The issue describes a local cache namespace collision between `repo-lyzer analyze` (TUI) and `repo-lyzer monitor` (real-time monitoring). Both subsystems were using the same raw key format `owner/repo` to store completely different data structures, resulting in mutual cache corruption.

### Changes
- Introduced prefixes to separate cache keys for each namespace:
  - `"analysis:"` for analysis results (e.g. `analysis:owner/repo`)
  - `"monitor:"` for monitoring state (e.g. `monitor:owner/repo`)
- Updated `repoToFilename` in `internal/cache/cache.go` to replace colons (`:`) with underscores (`_`). This prevents filesystem/path issues on operating systems like Windows that don't support colons in filenames.
- Prefixed all cache access operations in:
  - `internal/ui/app.go` (analysis TUI)
  - `internal/monitor/monitor.go` (real-time monitor)
- Updated unit tests in `cache_test.go` and `monitor_state_test.go` to verify correctness and cover namespace prefixes.

Closes #333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized cache filenames to remove characters that could produce invalid filenames.
  * Introduced namespaced cache keys for analysis and monitoring to keep cached data isolated and consistent.

* **Tests**
  * Expanded tests to verify the new filename sanitization and namespaced cache key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->