### PR TITLE
fix(scheduler): bound webhook delivery time

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -5,6 +5,7 @@ package scheduler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -31,6 +32,10 @@ type Scheduler struct {
 
 // ReportExporter handles exporting analysis reports to various formats
 type ReportExporter struct{}
+
+const webhookRequestTimeout = 30 * time.Second
+
+var webhookHTTPClient = &http.Client{Timeout: webhookRequestTimeout}
 
 // NewScheduler creates a new scheduler instance
 func NewScheduler() (*Scheduler, error) {
@@ -281,7 +286,16 @@ func (s *Scheduler) sendToWebhook(webhookURL, filename string, data []byte) erro
 		return fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
-	resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(jsonData))
+	ctx, cancel := context.WithTimeout(context.Background(), webhookRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to build webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := webhookHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send webhook: %w", err)
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,39 @@
+package scheduler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSendToWebhookTimesOutWhenReceiverStalls verifies webhook delivery fails
+// fast when a receiver accepts the request but never responds.
+func TestSendToWebhookTimesOutWhenReceiverStalls(t *testing.T) {
+	originalClient := webhookHTTPClient
+	webhookHTTPClient = &http.Client{Timeout: 25 * time.Millisecond}
+	t.Cleanup(func() {
+		webhookHTTPClient = originalClient
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	start := time.Now()
+	err := (&Scheduler{}).sendToWebhook(server.URL, "report.json", []byte(`{"score":90}`))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected stalled webhook receiver to return a timeout error")
+	}
+	if !strings.Contains(err.Error(), "failed to send webhook") {
+		t.Fatalf("expected webhook send error, got %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("webhook call was not bounded by the configured timeout; elapsed %s", elapsed)
+	}
+}


### PR DESCRIPTION
## What
Fixes #391 by adding a bounded HTTP client for scheduled webhook report delivery. Webhook destinations that accept a connection but do not respond now fail through the existing error path instead of blocking the scheduled job indefinitely.

## How
Replaced the package-level `http.Post` call in `sendToWebhook` with a scheduler-local `http.Client` configured with a 30 second timeout. Added a focused regression test using a stalled `httptest.Server` and a short test client timeout to prove the call returns promptly.

## Testing
- `go test ./internal/scheduler`
- `go test ./internal/scheduler ./internal/github ./internal/config`
- `go test ./...`
- `git diff --cached --check`

## Risks / Notes
Low risk. The change only affects scheduled webhook delivery; successful responses and non-2xx error handling keep the same behavior. The timeout is long enough for normal webhook receivers while preventing indefinite scheduler stalls.

Closes #391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook delivery now uses a consistent timeout, preventing indefinite hangs and improving reliability.
* **Tests**
  * Added a test verifying webhook sends fail promptly when receivers stall, ensuring timeout behavior is enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->