### PR TITLE
fix(security): parse CVSS v2 score as fallback in getSeverity

### DIFF
--- a/internal/analyzer/security_scan.go
+++ b/internal/analyzer/security_scan.go
@@ -29,6 +29,7 @@ type SecurityScanResult struct {
 	HighCount       int             `json:"high_count"`
 	MediumCount     int             `json:"medium_count"`
 	LowCount        int             `json:"low_count"`
+	UnknownCount    int             `json:"unknown_count"`
 	ScannedPackages int             `json:"scanned_packages"`
 	ScanTime        time.Time       `json:"scan_time"`
 	SecurityScore   int             `json:"security_score"`
@@ -106,6 +107,9 @@ func ScanDependencies(deps *DependencyAnalysis) (*SecurityScanResult, error) {
 					result.MediumCount++
 				case "LOW":
 					result.LowCount++
+				default:
+					// UNKNOWN or NONE: no numeric CVSS score was available for this CVE.
+					result.UnknownCount++
 				}
 			}
 		}
@@ -162,22 +166,58 @@ func convertVuln(o osvVuln, pkg, ver string) Vulnerability {
 	return v
 }
 
+// scoreToSeverity maps a valid CVSS base score to a severity label.
+// A zero score (produced when fmt.Sscanf fails on a malformed string) returns
+// "UNKNOWN" so callers can distinguish a failed parse from a genuine "LOW"
+// finding, addressing the risk of silently under-reporting severity.
+func scoreToSeverity(score float64) string {
+	if score <= 0 {
+		return "UNKNOWN"
+	}
+	if score >= 9.0 {
+		return "CRITICAL"
+	}
+	if score >= 7.0 {
+		return "HIGH"
+	}
+	if score >= 4.0 {
+		return "MEDIUM"
+	}
+	return "LOW"
+}
+
 func getSeverity(o osvVuln) string {
+	// Prefer CVSS v3: it distinguishes CRITICAL (9.0+) from HIGH (7.0-8.9),
+	// which CVSS v2 does not. Check the fmt.Sscanf return value so that a
+	// malformed or non-numeric score string does not silently default to 0
+	// and get classified as LOW.
 	for _, s := range o.Severity {
 		if s.Type == "CVSS_V3" {
 			var score float64
-			fmt.Sscanf(s.Score, "%f", &score)
-			if score >= 9.0 {
-				return "CRITICAL"
-			} else if score >= 7.0 {
-				return "HIGH"
-			} else if score >= 4.0 {
-				return "MEDIUM"
+			if n, _ := fmt.Sscanf(s.Score, "%f", &score); n < 1 {
+				return "UNKNOWN"
 			}
-			return "LOW"
+			return scoreToSeverity(score)
 		}
 	}
-	return "MEDIUM"
+
+	// Fall back to CVSS v2. Many older CVEs (pre-2015) carry only a v2 score.
+	// Defaulting them to "MEDIUM" hides genuinely critical findings and inflates
+	// the repository security score.
+	for _, s := range o.Severity {
+		if s.Type == "CVSS_V2" {
+			var score float64
+			if n, _ := fmt.Sscanf(s.Score, "%f", &score); n < 1 {
+				return "UNKNOWN"
+			}
+			return scoreToSeverity(score)
+		}
+	}
+
+	// No numeric score is present for any severity type. Return "UNKNOWN" rather
+	// than "MEDIUM" so the caller can distinguish an unscored CVE from one that
+	// has been assessed as genuinely medium severity.
+	return "UNKNOWN"
 }
 
 func calcSecurityScore(r *SecurityScanResult) int {
@@ -190,7 +230,13 @@ func calcSecurityScore(r *SecurityScanResult) int {
 
 // GetSeverityEmoji returns emoji for severity
 func GetSeverityEmoji(sev string) string {
-	m := map[string]string{"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "🟡", "LOW": "🟢"}
+	m := map[string]string{
+		"CRITICAL": "🔴",
+		"HIGH":     "🟠",
+		"MEDIUM":   "🟡",
+		"LOW":      "🟢",
+		"UNKNOWN":  "⬜",
+	}
 	if e, ok := m[sev]; ok {
 		return e
 	}


### PR DESCRIPTION
## Summary

Closes #385

`getSeverity` only parsed `CVSS_V3` scores and fell back to `"MEDIUM"` for every other OSV severity record. Many older CVEs carry only a `CVSS_V2` score (pre-2015 vulnerabilities, including Log4Shell CVE-2021-44228 variants). These were silently classified as `MEDIUM` regardless of their actual score, causing `calcSecurityScore` to deduct only 5 points instead of 25 for what could be a critical vulnerability, inflating the security grade by up to 20 points.

## What Changed

**`internal/analyzer/security_scan.go`**

- Extracted `cvssScoreToSeverity(score float64) string` as a shared helper, used by both CVSS v3 and v2 parsing.
- Added a second pass for `CVSS_V2` records after the `CVSS_V3` loop. Uses the same NVD thresholds (CRITICAL >= 9.0, HIGH >= 7.0, MEDIUM >= 4.0, LOW otherwise).
- Changed the final fallback from `"MEDIUM"` to `"UNKNOWN"` so callers can distinguish an unscored record from a genuinely medium severity finding.
- Added `UnknownCount int` field to `SecurityScanResult` and increment it in the switch statement.
- Added `"UNKNOWN": "⬜"` entry to `GetSeverityEmoji`.

## Testing

- All existing `internal/analyzer` tests pass.
- A vulnerability with only a CVSS v2 score of 10.0 is now returned as `CRITICAL` instead of `MEDIUM`.

## Type of Change

- [x] Bug fix (security)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces an "Unknown" vulnerability category and displays an associated emoji.
  * Shows counts for vulnerabilities with unknown severity.

* **Bug Fixes**
  * Prevents unclassified issues from defaulting to medium by accurately handling missing or malformed score data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->