### PR TITLE
fix(github): propagate token clear to live Client instances

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
-	
 	gocache "github.com/patrickmn/go-cache"
 	"golang.org/x/sync/singleflight"
 )
@@ -18,6 +18,7 @@ import (
 // Client handles GitHub API requests
 type Client struct {
 	http  *http.Client
+	mu    sync.RWMutex // guards token
 	token string
 	ctx   context.Context
 	cache *gocache.Cache
@@ -55,13 +56,17 @@ func (c *Client) SetContext(ctx context.Context) {
 
 // HasToken returns true if a GitHub token is configured
 func (c *Client) HasToken() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.token != ""
 }
 
 // SetToken sets the GitHub token for authentication.
 // The previous token value is overwritten so subsequent requests use the new token.
 func (c *Client) SetToken(token string) {
+	c.mu.Lock()
 	c.token = token
+	c.mu.Unlock()
 	c.cache.Flush()
 }
 
@@ -69,8 +74,12 @@ func (c *Client) SetToken(token string) {
 // requests are made without authentication. Call this on every live Client after
 // ClearGitHubToken() is invoked on the settings, otherwise the old token
 // persists in memory and continues to be sent in API request headers.
+// This does not affect requests already in flight; only future calls to get()
+// will omit the Authorization header.
 func (c *Client) ClearToken() {
+	c.mu.Lock()
 	c.token = ""
+	c.mu.Unlock()
 }
 
 // get performs a GET request to the GitHub API and decodes the JSON response.
@@ -87,8 +96,11 @@ func (c *Client) get(url string, target interface{}) error {
 		}
 
 		req.Header.Set("Accept", "application/vnd.github+json")
-		if c.token != "" {
-			req.Header.Set("Authorization", "Bearer "+c.token)
+		c.mu.RLock()
+		tok := c.token
+		c.mu.RUnlock()
+		if tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
 		}
 
 		resp, err := c.http.Do(req)
@@ -131,7 +143,10 @@ func (c *Client) get(url string, target interface{}) error {
 
 				resp.Body.Close()
 				// If unauthenticated, return informative error after waiting once
-				if c.token == "" {
+				c.mu.RLock()
+				noToken := c.token == ""
+				c.mu.RUnlock()
+				if noToken {
 					select {
 					case <-time.After(waitTime + time.Second):
 						return fmt.Errorf("rate limit exceeded and no token configured; consider setting GITHUB_TOKEN")

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -58,10 +58,19 @@ func (c *Client) HasToken() bool {
 	return c.token != ""
 }
 
-// SetToken sets the GitHub token for authentication
+// SetToken sets the GitHub token for authentication.
+// The previous token value is overwritten so subsequent requests use the new token.
 func (c *Client) SetToken(token string) {
 	c.token = token
 	c.cache.Flush()
+}
+
+// ClearToken removes the GitHub token from this Client instance so subsequent
+// requests are made without authentication. Call this on every live Client after
+// ClearGitHubToken() is invoked on the settings, otherwise the old token
+// persists in memory and continues to be sent in API request headers.
+func (c *Client) ClearToken() {
+	c.token = ""
 }
 
 // get performs a GET request to the GitHub API and decodes the JSON response.

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -119,6 +119,13 @@ func (m *Monitor) Stop() {
 	m.cancel()
 }
 
+// ClearToken removes the GitHub token from the underlying API client so
+// subsequent monitoring requests are made without authentication.
+// Call this whenever the user clears their GitHub token in settings.
+func (m *Monitor) ClearToken() {
+	m.client.ClearToken()
+}
+
 // monitorLoop runs the main monitoring loop
 func (m *Monitor) monitorLoop() {
 	defer m.wg.Done()

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -635,6 +635,9 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.err = fmt.Errorf("Cache cleared")
 				} else if m.settingsOption == "token" && m.appConfig != nil {
 					m.appConfig.ClearGitHubToken()
+					// Propagate the clear to any live monitor so the old token is
+					// no longer used in subsequent API requests from that instance.
+					m.monitorDashboard.ClearToken()
 					m.err = fmt.Errorf("GitHub token cleared")
 				}
 			case "x":

--- a/internal/ui/monitor_dashboard.go
+++ b/internal/ui/monitor_dashboard.go
@@ -100,7 +100,9 @@ func (m *MonitorDashboardModel) StopMonitoring() {
 }
 
 // ClearToken propagates a token clear to the active monitor so it no longer
-// sends the old token on in-flight or future API requests.
+// sends the old token on future API requests. Requests that are already in
+// flight retain their Authorization header because it was set when the request
+// was built; only subsequent calls to get() will omit it.
 func (m *MonitorDashboardModel) ClearToken() {
 	if m.monitor != nil {
 		m.monitor.ClearToken()

--- a/internal/ui/monitor_dashboard.go
+++ b/internal/ui/monitor_dashboard.go
@@ -99,6 +99,14 @@ func (m *MonitorDashboardModel) StopMonitoring() {
 	m.isMonitoring = false
 }
 
+// ClearToken propagates a token clear to the active monitor so it no longer
+// sends the old token on in-flight or future API requests.
+func (m *MonitorDashboardModel) ClearToken() {
+	if m.monitor != nil {
+		m.monitor.ClearToken()
+	}
+}
+
 func (m MonitorDashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:


### PR DESCRIPTION
## Summary

Closes #386

`ClearGitHubToken()` in `internal/config/settings.go` zeroed the settings struct and keyring entry but never reached live `Client` instances. Any `Monitor` (or other long-lived object) created before the clear continued holding the old token string in `Client.token` and continued to send it in the `Authorization` header on all subsequent API requests.

## What Changed

**`internal/github/client.go`**
- Added `ClearToken()` method that sets `c.token = ""`. Subsequent calls to `get()` will see an empty token and make unauthenticated requests.

**`internal/monitor/monitor.go`**
- Added `ClearToken()` on `Monitor` that delegates to `m.client.ClearToken()`.

**`internal/ui/monitor_dashboard.go`**
- Added `ClearToken()` on `MonitorDashboardModel` that delegates to `m.monitor.ClearToken()` (nil-safe).

**`internal/ui/app.go`**
- Added `m.monitorDashboard.ClearToken()` immediately after `m.appConfig.ClearGitHubToken()` in the settings "clear token" key handler, so the running monitor (if any) stops using the old token without requiring a restart.

## Testing

1. Start monitoring a repository with a valid token.
2. Navigate to Settings and clear the token.
3. Confirm that subsequent monitoring API calls return `401 Unauthorized` instead of succeeding with the old token.

## Type of Change

- [x] Bug fix (security)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing the GitHub token in Settings now reliably removes the token from all monitoring components so subsequent monitoring requests run without prior authentication.
  * The monitoring dashboard and background monitor processes now stop using previously stored tokens immediately after the token is cleared, preventing unintended authenticated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->