### PR TITLE
fix: apply saved GitHub token from settings to API client (issue #398)

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -34,6 +34,16 @@ func NewClient() *Client {
 	}
 }
 
+// NewClientWithToken creates a client pre-configured with the given token.
+// If token is empty, behaves identically to NewClient().
+func NewClientWithToken(token string) *Client {
+	c := NewClient()
+	if token != "" {
+		c.SetToken(token)
+	}
+	return c
+}
+
 // SetContext sets the context used to cancel in-flight HTTP requests.
 func (c *Client) SetContext(ctx context.Context) {
 	if ctx == nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -100,6 +100,9 @@ func (s *Scheduler) executeJob(job config.ScheduledJob) error {
 
 	// Initialize GitHub client
 	client := github.NewClient()
+	if s.settings != nil && s.settings.HasGitHubToken() {
+		client.SetToken(s.settings.GitHubToken)
+	}
 
 	// Fetch repository information
 	repoInfo, err := client.GetRepo(job.Owner, job.Repo)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -99,10 +99,11 @@ func (s *Scheduler) executeJob(job config.ScheduledJob) error {
 	startTime := time.Now()
 
 	// Initialize GitHub client
-	client := github.NewClient()
-	if s.settings != nil && s.settings.HasGitHubToken() {
-		client.SetToken(s.settings.GitHubToken)
+	token := ""
+	if s.settings != nil {
+		token = s.settings.GitHubToken
 	}
+	client := github.NewClientWithToken(token)
 
 	// Fetch repository information
 	repoInfo, err := client.GetRepo(job.Owner, job.Repo)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -855,6 +855,9 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 
 		// Stage 1: Fetch repository
 		client := github.NewClient()
+		if m.appConfig != nil && m.appConfig.HasGitHubToken() {
+			client.SetToken(m.appConfig.GitHubToken)
+		}
 		client.SetContext(ctx)
 		repo, err := client.GetRepo(parts[0], parts[1])
 		if err != nil {
@@ -1066,6 +1069,9 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 
 func (m MainModel) checkOwnership() bool {
 	client := github.NewClient()
+	if m.appConfig != nil && m.appConfig.HasGitHubToken() {
+		client.SetToken(m.appConfig.GitHubToken)
+	}
 	user, err := client.GetUser()
 	if err != nil {
 		return false // If we can't get user, assume not owner
@@ -1228,6 +1234,9 @@ func (m MainModel) compareRepos(repo1Name, repo2Name string) tea.Cmd {
 		}
 
 		client := github.NewClient()
+		if m.appConfig != nil && m.appConfig.HasGitHubToken() {
+			client.SetToken(m.appConfig.GitHubToken)
+		}
 
 		// Analyze first repo
 		repo1, err := client.GetRepo(parts1[0], parts1[1])

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -854,10 +854,11 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 		tracker := NewProgressTracker()
 
 		// Stage 1: Fetch repository
-		client := github.NewClient()
-		if m.appConfig != nil && m.appConfig.HasGitHubToken() {
-			client.SetToken(m.appConfig.GitHubToken)
+		token := ""
+		if m.appConfig != nil {
+			token = m.appConfig.GitHubToken
 		}
+		client := github.NewClientWithToken(token)
 		client.SetContext(ctx)
 		repo, err := client.GetRepo(parts[0], parts[1])
 		if err != nil {
@@ -1068,10 +1069,11 @@ func (m MainModel) analyzeRepo(ctx context.Context, repoName string) tea.Cmd {
 }
 
 func (m MainModel) checkOwnership() bool {
-	client := github.NewClient()
-	if m.appConfig != nil && m.appConfig.HasGitHubToken() {
-		client.SetToken(m.appConfig.GitHubToken)
+	token := ""
+	if m.appConfig != nil {
+		token = m.appConfig.GitHubToken
 	}
+	client := github.NewClientWithToken(token)
 	user, err := client.GetUser()
 	if err != nil {
 		return false // If we can't get user, assume not owner
@@ -1233,10 +1235,11 @@ func (m MainModel) compareRepos(repo1Name, repo2Name string) tea.Cmd {
 			return fmt.Errorf("invalid repository URL: second repository must be in owner/repo format or a valid GitHub URL")
 		}
 
-		client := github.NewClient()
-		if m.appConfig != nil && m.appConfig.HasGitHubToken() {
-			client.SetToken(m.appConfig.GitHubToken)
+		token := ""
+		if m.appConfig != nil {
+			token = m.appConfig.GitHubToken
 		}
+		client := github.NewClientWithToken(token)
 
 		// Analyze first repo
 		repo1, err := client.GetRepo(parts1[0], parts1[1])


### PR DESCRIPTION
## Problem
`github.NewClient()` only reads `GITHUB_TOKEN` from the environment. Users who saved a token via the TUI settings never had it applied to the client, causing unauthenticated rate limit errors and inability to access private repos despite having configured a token.

## Fix
After every `github.NewClient()` call in `internal/ui/app.go` and `internal/scheduler/scheduler.go`, the saved token from settings is now applied via `client.SetToken()` when present.

## Changes
- `internal/ui/app.go` — token applied in `analyzeRepo`, `checkOwnership`, and `compareRepos`
- `internal/scheduler/scheduler.go` — token applied in `executeJob`

## Verification
`go build ./...` and `go test ./...` both pass with zero errors.

Closes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub API token handling: the app now consistently applies a configured token (when present) before repository analysis, ownership checks, and comparisons, preventing authentication errors when token settings are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->