### PR TITLE
fix: surface truncated file tree warning instead of silently using partial data (issue #402)

### DIFF
--- a/internal/github/tree.go
+++ b/internal/github/tree.go
@@ -1,5 +1,7 @@
 package github
 
+import "fmt"
+
 type TreeEntry struct {
 	Path string `json:"path"`
 	Mode string `json:"mode"`
@@ -19,5 +21,11 @@ func (c *Client) GetFileTree(owner, repo, branch string) ([]TreeEntry, error) {
 	var t TreeResponse
 	// recursive=1 to get full tree
 	err := c.get("https://api.github.com/repos/"+owner+"/"+repo+"/git/trees/"+branch+"?recursive=1", &t)
-	return t.Tree, err
+	if err != nil {
+		return nil, err
+	}
+	if t.Truncated {
+		return t.Tree, fmt.Errorf("file tree truncated by GitHub: results may be incomplete for large repositories")
+	}
+	return t.Tree, nil
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1239,7 +1239,7 @@ func (m MainModel) compareRepos(repo1Name, repo2Name string) tea.Cmd {
 		languages1, _ := client.GetLanguages(parts1[0], parts1[1])
 		fileTree1, err := client.GetFileTree(parts1[0], parts1[1], repo1.DefaultBranch)
 		if err != nil {
-			fmt.Printf("⚠️ %v\n", err)
+			fmt.Printf("⚠️  %s: %v\n", repo1Name, err)
 		}
 		score1 := analyzer.CalculateHealth(repo1, commits1)
 		busFactor1, busRisk1 := analyzer.BusFactor(contributors1)
@@ -1268,7 +1268,7 @@ func (m MainModel) compareRepos(repo1Name, repo2Name string) tea.Cmd {
 		languages2, _ := client.GetLanguages(parts2[0], parts2[1])
 		fileTree2, err := client.GetFileTree(parts2[0], parts2[1], repo2.DefaultBranch)
 		if err != nil {
-			fmt.Printf("⚠️ %v\n", err)
+			fmt.Printf("⚠️  %s: %v\n", repo2Name, err)
 		}
 		score2 := analyzer.CalculateHealth(repo2, commits2)
 		busFactor2, busRisk2 := analyzer.BusFactor(contributors2)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1237,7 +1237,10 @@ func (m MainModel) compareRepos(repo1Name, repo2Name string) tea.Cmd {
 		commits1, _ := client.GetCommits(parts1[0], parts1[1], 365)
 		contributors1, _ := client.GetContributorsWithAvatars(parts1[0], parts1[1], 15)
 		languages1, _ := client.GetLanguages(parts1[0], parts1[1])
-		fileTree1, _ := client.GetFileTree(parts1[0], parts1[1], repo1.DefaultBranch)
+		fileTree1, err := client.GetFileTree(parts1[0], parts1[1], repo1.DefaultBranch)
+		if err != nil {
+			fmt.Printf("⚠️ %v\n", err)
+		}
 		score1 := analyzer.CalculateHealth(repo1, commits1)
 		busFactor1, busRisk1 := analyzer.BusFactor(contributors1)
 		maturityScore1, maturityLevel1 := analyzer.RepoMaturityScore(repo1, len(commits1), len(contributors1), false)
@@ -1263,7 +1266,10 @@ func (m MainModel) compareRepos(repo1Name, repo2Name string) tea.Cmd {
 		commits2, _ := client.GetCommits(parts2[0], parts2[1], 365)
 		contributors2, _ := client.GetContributorsWithAvatars(parts2[0], parts2[1], 15)
 		languages2, _ := client.GetLanguages(parts2[0], parts2[1])
-		fileTree2, _ := client.GetFileTree(parts2[0], parts2[1], repo2.DefaultBranch)
+		fileTree2, err := client.GetFileTree(parts2[0], parts2[1], repo2.DefaultBranch)
+		if err != nil {
+			fmt.Printf("⚠️ %v\n", err)
+		}
 		score2 := analyzer.CalculateHealth(repo2, commits2)
 		busFactor2, busRisk2 := analyzer.BusFactor(contributors2)
 		maturityScore2, maturityLevel2 := analyzer.RepoMaturityScore(repo2, len(commits2), len(contributors2), false)


### PR DESCRIPTION
## Problem
`GetFileTree` in `internal/github/tree.go` ignored the `Truncated` field in GitHub's response. For large repositories where GitHub truncates the recursive tree, callers ran full analysis on partial data with no warning, producing silently incorrect results.

## Fix
- Added `fmt.Errorf` return when `t.Truncated` is true in `GetFileTree`
- `analyzeRepo` in `app.go` already propagated the error correctly — no change needed
- `compareRepos` in `app.go` previously discarded the error with `_` — updated to print a warning and continue with the partial tree
- `cmd/analyze.go` already returned the error correctly — no change needed

## Changes
- `internal/github/tree.go` — import `fmt`, check `t.Truncated`, return descriptive error
- `internal/ui/app.go` — fix silent discard in `compareRepos`

## Verification
`go build ./...` and `go test ./...` both pass with zero errors.

Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection and reporting when file tree results may be incomplete (truncated).
  * Improved handling of file tree retrieval errors so comparisons continue using available data.
  * Repository comparison now emits warnings when file tree fetches fail, preserving comparison output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->