### PR TITLE
fix: add pagination to GetIssues to fetch all issues beyond 100 (issue #404)

### DIFF
--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -1,6 +1,9 @@
 package github
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type IssueLabel struct {
 	Name  string `json:"name"`
@@ -21,8 +24,37 @@ type Issue struct {
 }
 
 func (c *Client) GetIssues(owner, repo string, state string) ([]Issue, error) {
-	var issues []Issue
-	url := "https://api.github.com/repos/" + owner + "/" + repo + "/issues?state=" + state + "&per_page=100"
-	err := c.get(url, &issues)
-	return issues, err
+	var allIssues []Issue
+
+	page := 1
+	perPage := 100
+
+	for {
+		url := fmt.Sprintf(
+			"https://api.github.com/repos/%s/%s/issues?state=%s&per_page=%d&page=%d",
+			owner, repo, state, perPage, page,
+		)
+
+		var issues []Issue
+		err := c.get(url, &issues)
+		if err != nil {
+			return nil, err
+		}
+
+		// Stop when no more issues
+		if len(issues) == 0 {
+			break
+		}
+
+		allIssues = append(allIssues, issues...)
+
+		// Stop when fewer than per_page (last page)
+		if len(issues) < perPage {
+			break
+		}
+
+		page++
+	}
+
+	return allIssues, nil
 }


### PR DESCRIPTION
## Problem
`GetIssues` in `internal/github/issues.go` performed a single GET request with `per_page=100` and no pagination. Repositories with more than 100 open issues returned incomplete data, skewing maintainer dashboards and contribution scoring metrics.

## Fix
Replaced the single-page fetch with a paginated loop mirroring the existing `GetPullRequests` pattern in `internal/github/pulls.go`:
- Pages start at 1 with `per_page=100`
- Results appended to `allIssues` each page
- Loop breaks when a page returns fewer than 100 items or is empty
- Returns `nil, err` on API failure

## Changes
- Only `internal/github/issues.go` modified
- Added `fmt` import
- `Issue` struct and function signature unchanged

## Verification
`go build ./...` and `go test ./...` both pass with zero errors.

Closes #404