### PR TITLE
fix: resolve concurrent map read/write panic in Scheduler via sync.RWMutex

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync" // SECURITY FIX: Imported sync for RWMutex
+	"sync" // SECURITY FIX: Imported sync for Mutex
 	"time"
 
 	"github.com/agnivo988/Repo-lyzer/internal/analyzer"
@@ -24,7 +24,7 @@ import (
 
 // Scheduler manages scheduled analysis report jobs
 type Scheduler struct {
-	mu             sync.RWMutex // SECURITY FIX: Mutex to prevent concurrent map read/write panic
+	mu             sync.Mutex // SECURITY FIX: Mutex to prevent concurrent map read/write panic
 	cron           *cron.Cron
 	settings       *config.AppSettings
 	jobEntries     map[string]cron.EntryID
@@ -91,10 +91,10 @@ func (s *Scheduler) scheduleJob(job config.ScheduledJob) error {
 		return fmt.Errorf("failed to add cron job: %w", err)
 	}
 
-	// SECURITY FIX: Lock map before writing
+	// SECURITY FIX: Lock map before writing (using defer for safety)
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.jobEntries[job.ID] = entryID
-	s.mu.Unlock()
 
 	log.Printf("Job %s scheduled with spec: %s", job.ID, spec)
 	return nil
@@ -318,11 +318,11 @@ func (s *Scheduler) AddJob(job config.ScheduledJob) error {
 func (s *Scheduler) RemoveJob(jobID string) error {
 	// SECURITY FIX: Lock map before read/delete
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if entryID, ok := s.jobEntries[jobID]; ok {
 		s.cron.Remove(entryID)
 		delete(s.jobEntries, jobID)
 	}
-	s.mu.Unlock()
 
 	return s.settings.RemoveScheduledJob(jobID)
 }
@@ -353,11 +353,11 @@ func (s *Scheduler) EnableJob(jobID string, enabled bool) error {
 	} else {
 		// SECURITY FIX: Lock map before read/delete
 		s.mu.Lock()
+		defer s.mu.Unlock()
 		if entryID, ok := s.jobEntries[jobID]; ok {
 			s.cron.Remove(entryID)
 			delete(s.jobEntries, jobID)
 		}
-		s.mu.Unlock()
 	}
 
 	return s.settings.EnableScheduledJob(jobID, enabled)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync" // SECURITY FIX: Imported sync for RWMutex
 	"time"
 
 	"github.com/agnivo988/Repo-lyzer/internal/analyzer"
@@ -23,6 +24,7 @@ import (
 
 // Scheduler manages scheduled analysis report jobs
 type Scheduler struct {
+	mu             sync.RWMutex // SECURITY FIX: Mutex to prevent concurrent map read/write panic
 	cron           *cron.Cron
 	settings       *config.AppSettings
 	jobEntries     map[string]cron.EntryID
@@ -89,7 +91,11 @@ func (s *Scheduler) scheduleJob(job config.ScheduledJob) error {
 		return fmt.Errorf("failed to add cron job: %w", err)
 	}
 
+	// SECURITY FIX: Lock map before writing
+	s.mu.Lock()
 	s.jobEntries[job.ID] = entryID
+	s.mu.Unlock()
+
 	log.Printf("Job %s scheduled with spec: %s", job.ID, spec)
 	return nil
 }
@@ -310,11 +316,13 @@ func (s *Scheduler) AddJob(job config.ScheduledJob) error {
 
 // RemoveJob removes a scheduled job
 func (s *Scheduler) RemoveJob(jobID string) error {
-	// Remove from cron if scheduled
+	// SECURITY FIX: Lock map before read/delete
+	s.mu.Lock()
 	if entryID, ok := s.jobEntries[jobID]; ok {
 		s.cron.Remove(entryID)
 		delete(s.jobEntries, jobID)
 	}
+	s.mu.Unlock()
 
 	return s.settings.RemoveScheduledJob(jobID)
 }
@@ -343,10 +351,13 @@ func (s *Scheduler) EnableJob(jobID string, enabled bool) error {
 			return fmt.Errorf("failed to schedule job: %w", err)
 		}
 	} else {
+		// SECURITY FIX: Lock map before read/delete
+		s.mu.Lock()
 		if entryID, ok := s.jobEntries[jobID]; ok {
 			s.cron.Remove(entryID)
 			delete(s.jobEntries, jobID)
 		}
+		s.mu.Unlock()
 	}
 
 	return s.settings.EnableScheduledJob(jobID, enabled)
@@ -383,3 +394,4 @@ func FormatScheduleInterval() string {
 func GetCronExpressionForInterval(interval config.ScheduleInterval) string {
 	return interval.CronExpression()
 }
+

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync" // SECURITY FIX: Imported sync for Mutex
+	"sync" // SECURITY FIX: Imported sync for RWMutex
 	"time"
 
 	"github.com/agnivo988/Repo-lyzer/internal/analyzer"
@@ -24,7 +24,7 @@ import (
 
 // Scheduler manages scheduled analysis report jobs
 type Scheduler struct {
-	mu             sync.Mutex // SECURITY FIX: Mutex to prevent concurrent map read/write panic
+	mu             sync.RWMutex // SECURITY FIX: RWMutex as explicitly required by Issue #415
 	cron           *cron.Cron
 	settings       *config.AppSettings
 	jobEntries     map[string]cron.EntryID
@@ -91,7 +91,7 @@ func (s *Scheduler) scheduleJob(job config.ScheduledJob) error {
 		return fmt.Errorf("failed to add cron job: %w", err)
 	}
 
-	// SECURITY FIX: Lock map before writing (using defer for safety)
+	// SECURITY FIX: Write lock map before writing
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.jobEntries[job.ID] = entryID
@@ -316,12 +316,17 @@ func (s *Scheduler) AddJob(job config.ScheduledJob) error {
 
 // RemoveJob removes a scheduled job
 func (s *Scheduler) RemoveJob(jobID string) error {
-	// SECURITY FIX: Lock map before read/delete
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if entryID, ok := s.jobEntries[jobID]; ok {
+	// SECURITY FIX: Read lock map before checking existence
+	s.mu.RLock()
+	entryID, ok := s.jobEntries[jobID]
+	s.mu.RUnlock()
+
+	if ok {
+		// SECURITY FIX: Write lock map before modifying
+		s.mu.Lock()
 		s.cron.Remove(entryID)
 		delete(s.jobEntries, jobID)
+		s.mu.Unlock()
 	}
 
 	return s.settings.RemoveScheduledJob(jobID)
@@ -351,12 +356,17 @@ func (s *Scheduler) EnableJob(jobID string, enabled bool) error {
 			return fmt.Errorf("failed to schedule job: %w", err)
 		}
 	} else {
-		// SECURITY FIX: Lock map before read/delete
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		if entryID, ok := s.jobEntries[jobID]; ok {
+		// SECURITY FIX: Read lock map before checking existence
+		s.mu.RLock()
+		entryID, ok := s.jobEntries[jobID]
+		s.mu.RUnlock()
+
+		if ok {
+			// SECURITY FIX: Write lock map before modifying
+			s.mu.Lock()
 			s.cron.Remove(entryID)
 			delete(s.jobEntries, jobID)
+			s.mu.Unlock()
 		}
 	}
 


### PR DESCRIPTION
Description
This PR patches a critical Go runtime panic (fatal error: concurrent map read and map write) caused by unprotected reads and writes to Scheduler.jobEntries.

Changes:

Injected a sync.RWMutex into the Scheduler struct.

Safely wrapped all map write and delete operations inside scheduleJob, RemoveJob, and EnableJob using s.mu.Lock() / s.mu.Unlock() to ensure thread-safe execution across goroutines.

GSSoC 2026 Contribution
Fixes #415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue in the job scheduler that could cause crashes or lost jobs when schedules were modified concurrently; scheduler updates and removals are now serialized to prevent race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->