### PR TITLE
[BUG]: Case-sensitivity bug in findLicenseFiles prevents detection of LICENSE.md / LICENSE.txt

### DIFF
--- a/internal/analyzer/license.go
+++ b/internal/analyzer/license.go
@@ -218,7 +218,7 @@ func findLicenseFiles(tree []github.TreeEntry) []string {
 		filename := strings.ToUpper(parts[len(parts)-1])
 
 		for _, licenseName := range licenseNames {
-			if filename == licenseName || strings.ToUpper(filename) == licenseName {
+			if filename == strings.ToUpper(licenseName) {
 				files = append(files, entry.Path)
 				break
 			}


### PR DESCRIPTION
Resolves #428

This PR implements the fix proposed in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license file detection to properly match filenames using consistent case-normalization, ensuring license files are correctly identified regardless of filename casing variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->