### PR TITLE
[BUG]: OSV vulnerability scanning fails for Python packages with operators in version strings

### DIFF
--- a/internal/analyzer/security_scan.go
+++ b/internal/analyzer/security_scan.go
@@ -126,7 +126,8 @@ func queryOSV(client *http.Client, pkg, ver, eco string) ([]osvVuln, error) {
 	query := osvQuery{}
 	query.Package.Name = pkg
 	query.Package.Ecosystem = eco
-	ver = strings.TrimPrefix(strings.TrimPrefix(ver, "^"), "~")
+	// Strip all leading version comparison operators (e.g. ==, >=, <=, ~, ^)
+	ver = strings.TrimLeft(ver, "=<>!~^ ")
 	if ver != "" && ver != "*" {
 		query.Version = ver
 	}


### PR DESCRIPTION
Resolves #430

This PR implements the fix proposed in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced version string normalization in dependency security analysis to properly handle a wider range of version format patterns, improving scan accuracy and consistency across various dependency declaration conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->