### PR TITLE
[BUG]: Unescaped file paths in GetFileContent cause 404 errors on files with special characters

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -199,7 +200,13 @@ func (c *Client) GetFileContent(owner, repo, path string) (string, error) {
 			return cached.(string), nil
 		}
 
-		url := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s", owner, repo, path)
+		// Escape each path segment to handle special characters (spaces, hashes, etc.)
+		segments := strings.Split(path, "/")
+		for i, seg := range segments {
+			segments[i] = url.PathEscape(seg)
+		}
+		escapedPath := strings.Join(segments, "/")
+		url := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s", owner, repo, escapedPath)
 
 		var result struct {
 			Content  string `json:"content"`


### PR DESCRIPTION
Resolves #432

This PR implements the fix proposed in the issue.