### PR TITLE
fix(github): add pagination to GetIssues to fetch all issues beyond 100 #404fix(github): add pagination loop to GetIssues and refactor client Bas…

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -17,11 +17,12 @@ import (
 
 // Client handles GitHub API requests
 type Client struct {
-	http  *http.Client
-	token string
-	ctx   context.Context
-	cache *gocache.Cache
-	sf    singleflight.Group
+	http    *http.Client
+	token   string
+	ctx     context.Context
+	cache   *gocache.Cache
+	sf      singleflight.Group
+	BaseURL string
 }
 
 // User represents a GitHub user
@@ -41,6 +42,7 @@ func NewClient() *Client {
 			5*time.Minute,  // default expiration
 			10*time.Minute, // cleanup interval
 		),
+		BaseURL: "https://api.github.com",
 	}
 }
 
@@ -225,7 +227,7 @@ func (c *Client) GetUser() (*User, error) {
 		}
 
 		var u User
-		if err := c.get("https://api.github.com/user", &u); err != nil {
+		if err := c.get(c.BaseURL+"/user", &u); err != nil {
 			return nil, err
 		}
 
@@ -252,7 +254,7 @@ func (c *Client) GetUserByLogin(login string) (*User, error) {
 			return &u, nil
 		}
 
-		url := fmt.Sprintf("https://api.github.com/users/%s", login)
+		url := fmt.Sprintf("%s/users/%s", c.BaseURL, login)
 		var u User
 		if err := c.get(url, &u); err != nil {
 			return nil, err
@@ -280,7 +282,7 @@ func (c *Client) GetFileContent(owner, repo, path string) (string, error) {
 			return cached.(string), nil
 		}
 
-		url := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s", owner, repo, path)
+		url := fmt.Sprintf("%s/repos/%s/%s/contents/%s", c.BaseURL, owner, repo, path)
 
 		var result struct {
 			Content  string `json:"content"`

--- a/internal/github/commits.go
+++ b/internal/github/commits.go
@@ -52,9 +52,14 @@ func (c *Client) GetCommits(owner, repo string, days int) ([]Commit, error) {
 
 		for {
 			url := fmt.Sprintf(
-				"https://api.github.com/repos/%s/%s/commits?since=%s&per_page=%d&page=%d",
-				owner, repo, since, perPage, page,
+				"%s/repos/%s/%s/commits",
+				c.BaseURL, owner, repo,
 			)
+			if since != "" {
+				url += "?since=" + since + "&per_page=" + strconv.Itoa(perPage) + "&page=" + strconv.Itoa(page)
+			} else {
+				url += "?per_page=" + strconv.Itoa(perPage) + "&page=" + strconv.Itoa(page)
+			}
 
 			var commits []Commit
 			if err := c.get(url, &commits); err != nil {
@@ -100,7 +105,7 @@ func (c *Client) GetCommit(owner, repo, sha string) (*CommitDetail, error) {
 			return &d, nil
 		}
 
-		url := fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", owner, repo, sha)
+		url := fmt.Sprintf("%s/repos/%s/%s/commits/%s", c.BaseURL, owner, repo, sha)
 		var commit CommitDetail
 		if err := c.get(url, &commit); err != nil {
 			return nil, err

--- a/internal/github/contributor.go
+++ b/internal/github/contributor.go
@@ -33,8 +33,8 @@ func (c *Client) GetContributors(owner, repo string) ([]Contributor, error) {
 
 		for {
 			url := fmt.Sprintf(
-				"https://api.github.com/repos/%s/%s/contributors?per_page=%d&page=%d",
-				owner, repo, perPage, page,
+				"%s/repos/%s/%s/contributors?per_page=%d&page=%d",
+				c.BaseURL, owner, repo, perPage, page,
 			)
 
 			var contributors []Contributor

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"time"
 
 	gocache "github.com/patrickmn/go-cache"
@@ -35,14 +36,38 @@ func (c *Client) GetIssues(owner, repo string, state string) ([]Issue, error) {
 			return copyIssues(cached.([]Issue)), nil
 		}
 
-		var issues []Issue
-		url := "https://api.github.com/repos/" + owner + "/" + repo + "/issues?state=" + state + "&per_page=100"
-		if err := c.get(url, &issues); err != nil {
-			return nil, err
+		var allIssues []Issue
+		page := 1
+		perPage := 100
+
+		for {
+			url := fmt.Sprintf(
+				"%s/repos/%s/%s/issues?state=%s&per_page=%d&page=%d",
+				c.BaseURL, owner, repo, state, perPage, page,
+			)
+
+			var issues []Issue
+			if err := c.get(url, &issues); err != nil {
+				return nil, err
+			}
+
+			// Stop when no more issues
+			if len(issues) == 0 {
+				break
+			}
+
+			allIssues = append(allIssues, issues...)
+
+			// Stop when fewer than per_page (last page)
+			if len(issues) < perPage {
+				break
+			}
+
+			page++
 		}
 
-		c.cache.Set(cacheKey, issues, gocache.DefaultExpiration)
-		return copyIssues(issues), nil
+		c.cache.Set(cacheKey, allIssues, gocache.DefaultExpiration)
+		return copyIssues(allIssues), nil
 	})
 	if err != nil {
 		return nil, err

--- a/internal/github/issues_test.go
+++ b/internal/github/issues_test.go
@@ -1,0 +1,74 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetIssuesPagination(t *testing.T) {
+	// Create dummy issues for page 1 (full page) and page 2 (partial page)
+	page1 := make([]Issue, 100)
+	for i := 0; i < 100; i++ {
+		page1[i] = Issue{Number: i + 1}
+	}
+	page2 := []Issue{{Number: 101}, {Number: 102}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		
+		if page == "1" {
+			json.NewEncoder(w).Encode(page1)
+		} else if page == "2" {
+			json.NewEncoder(w).Encode(page2)
+		} else {
+			json.NewEncoder(w).Encode([]Issue{})
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.BaseURL = server.URL
+	client.http = server.Client() // Use server's client for the transport
+
+	issues, err := client.GetIssues("owner", "repo", "open")
+	if err != nil {
+		t.Fatalf("GetIssues failed: %v", err)
+	}
+
+	expectedCount := 102
+	if len(issues) != expectedCount {
+		t.Errorf("Expected %d issues, got %d", expectedCount, len(issues))
+	}
+
+	if issues[0].Number != 1 {
+		t.Errorf("Expected first issue number 1, got %d", issues[0].Number)
+	}
+
+	if issues[101].Number != 102 {
+		t.Errorf("Expected last issue number 102, got %d", issues[101].Number)
+	}
+}
+
+func TestGetIssuesEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]Issue{})
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.BaseURL = server.URL
+	client.http = server.Client()
+
+	issues, err := client.GetIssues("owner", "repo", "open")
+	if err != nil {
+		t.Fatalf("GetIssues failed: %v", err)
+	}
+
+	if len(issues) != 0 {
+		t.Errorf("Expected 0 issues, got %d", len(issues))
+	}
+}

--- a/internal/github/languages.go
+++ b/internal/github/languages.go
@@ -14,7 +14,7 @@ func (c *Client) GetLanguages(owner, repo string) (map[string]int, error) {
 		}
 
 		var langs map[string]int
-		if err := c.get("https://api.github.com/repos/"+owner+"/"+repo+"/languages", &langs); err != nil {
+		if err := c.get(c.BaseURL+"/repos/"+owner+"/"+repo+"/languages", &langs); err != nil {
 			return nil, err
 		}
 

--- a/internal/github/pulls.go
+++ b/internal/github/pulls.go
@@ -52,8 +52,8 @@ func (c *Client) GetPullRequests(owner, repo, state string) ([]PullRequest, erro
 
 		for {
 			url := fmt.Sprintf(
-				"https://api.github.com/repos/%s/%s/pulls?state=%s&per_page=%d&page=%d&sort=created&direction=desc",
-				owner, repo, state, perPage, page,
+				"%s/repos/%s/%s/pulls?state=%s&per_page=%d&page=%d&sort=created&direction=desc",
+				c.BaseURL, owner, repo, state, perPage, page,
 			)
 
 			var prs []PullRequest
@@ -107,8 +107,8 @@ func (c *Client) GetPullRequestsWithLimit(owner, repo, state string, limit int) 
 
 		for {
 			url := fmt.Sprintf(
-				"https://api.github.com/repos/%s/%s/pulls?state=%s&per_page=%d&page=%d&sort=created&direction=desc",
-				owner, repo, state, perPage, page,
+				"%s/repos/%s/%s/pulls?state=%s&per_page=%d&page=%d&sort=created&direction=desc",
+				c.BaseURL, owner, repo, state, perPage, page,
 			)
 
 			var prs []PullRequest
@@ -168,8 +168,8 @@ func (c *Client) GetPullRequestReviews(owner, repo string, prNumber int) ([]Revi
 
 		for {
 			url := fmt.Sprintf(
-				"https://api.github.com/repos/%s/%s/pulls/%d/reviews?per_page=%d&page=%d",
-				owner, repo, prNumber, perPage, page,
+				"%s/repos/%s/%s/pulls/%d/reviews?per_page=%d&page=%d",
+				c.BaseURL, owner, repo, prNumber, perPage, page,
 			)
 
 			var reviews []Review
@@ -218,8 +218,8 @@ func (c *Client) GetPullRequestDetails(owner, repo string, prNumber int) (*PullR
 		}
 
 		url := fmt.Sprintf(
-			"https://api.github.com/repos/%s/%s/pulls/%d",
-			owner, repo, prNumber,
+			"%s/repos/%s/%s/pulls/%d",
+			c.BaseURL, owner, repo, prNumber,
 		)
 
 		var pr PullRequest

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -41,7 +41,7 @@ func (c *Client) GetRepo(owner, repo string) (*Repo, error) {
 		}
 
 		var r Repo
-		if err := c.get("https://api.github.com/repos/"+owner+"/"+repo, &r); err != nil {
+		if err := c.get(c.BaseURL+"/repos/"+owner+"/"+repo, &r); err != nil {
 			return nil, err
 		}
 

--- a/internal/github/tree.go
+++ b/internal/github/tree.go
@@ -30,7 +30,7 @@ func (c *Client) GetFileTree(owner, repo, branch string) ([]TreeEntry, error) {
 
 		var t TreeResponse
 		// recursive=1 to get full tree
-		if err := c.get("https://api.github.com/repos/"+owner+"/"+repo+"/git/trees/"+branch+"?recursive=1", &t); err != nil {
+		if err := c.get(c.BaseURL+"/repos/"+owner+"/"+repo+"/git/trees/"+branch+"?recursive=1", &t); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Contributed as part of GSSoC '26.

###  Problem Description
The `GetIssues` method inside `internal/github/issues.go` previously executed a single HTTP GET request capped via `per_page=100`. Because it lacked a pagination mechanism, repositories containing greater than 100 open issues returned truncated datasets, leading to corrupted data flows within maintainer dashboards and metrics calculators. Fixes #404.

###  Solution Implemented
1. **Decoupled API Client Architecture:** Modernized the core `Client` struct in `internal/github/client.go` by replacing hardcoded API endpoints with an assignable `BaseURL` field (defaulting to `https://api.github.com`). Updated all package modules (`issues.go`, `pulls.go`, `commits.go`, etc.) to reference `c.BaseURL`, paving the way for proper, deterministic local mock assertions.
2. **Sequential Pagination Loop:** Implemented a stateful loop pattern inside `GetIssues` matching the `GetPullRequests` standard. The mechanism queries sequential pages starting at page 1, aggregates responses, and safely breaks execution when encountering a sparse page (fewer than 100 items) or an empty slice.
3. **Multi-Page Verification Engine:** Authored a complete verification suite in `internal/github/issues_test.go` utilizing `httptest.NewServer`. Tests securely validate a 2-page response bundle totaling 102 aggregate issue items alongside empty-state handling.

###  Verification & Test Logs
Executed the `internal/github` suite locally with green validation metrics:
* `TestGetIssuesPagination`: **PASSED** (Validated 102 items processed seamlessly across multiple pages)
* `TestGetIssuesEmpty`: **PASSED**