### PR TITLE
fix(analyzer): swap out unsafe rune casting for explicit bafix(analyzer): correct PR number string serialization to prevent data corruption #320se-10 PR s…

### DIFF
--- a/internal/analyzer/collaboration.go
+++ b/internal/analyzer/collaboration.go
@@ -3,6 +3,7 @@
 package analyzer
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -208,7 +209,7 @@ func analyzeCrossContributorPatterns(prs []github.PullRequest) CrossContributorP
 
 		// Create a "virtual" file entry per PR for analysis
 		// In production, we'd use commit file data
-		fileKey := "PR #" + string(rune(pr.Number+'0'))
+		fileKey := fmt.Sprintf("PR #%d", pr.Number)
 		if fileContributors[fileKey] == nil {
 			fileContributors[fileKey] = make(map[string]bool)
 		}

--- a/internal/analyzer/collaboration_test.go
+++ b/internal/analyzer/collaboration_test.go
@@ -1,0 +1,54 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/agnivo988/Repo-lyzer/internal/github"
+)
+
+func TestAnalyzeCrossContributorPatterns(t *testing.T) {
+	tests := []struct {
+		name     string
+		prs      []github.PullRequest
+		wantKeys []string
+	}{
+		{
+			name: "single digit PR number",
+			prs: []github.PullRequest{
+				{Number: 5, User: github.User{Login: "user1"}},
+			},
+			wantKeys: []string{"PR #5"},
+		},
+		{
+			name: "multi digit PR number",
+			prs: []github.PullRequest{
+				{Number: 12, User: github.User{Login: "user1"}},
+				{Number: 105, User: github.User{Login: "user2"}},
+			},
+			wantKeys: []string{"PR #12", "PR #105"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patterns := analyzeCrossContributorPatterns(tt.prs)
+			
+			if len(patterns.TopCollaboratedFiles) != len(tt.wantKeys) {
+				t.Errorf("analyzeCrossContributorPatterns() returned %d files, want %d", len(patterns.TopCollaboratedFiles), len(tt.wantKeys))
+			}
+
+			for _, wantKey := range tt.wantKeys {
+				found := false
+				for _, file := range patterns.TopCollaboratedFiles {
+					if file.Filename == wantKey {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("analyzeCrossContributorPatterns() = %v, want key %s", patterns.TopCollaboratedFiles, wantKey)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION

Contributed as part of GSSoC '26.

###  Problem Description
Inside `internal/analyzer/collaboration.go`, the `analyzeCrossContributorPatterns` function previously constructed map index keys using an implicit Unicode code-point casting strategy: `string(rune(pr.Number + '0'))`. 

While this coincidentally yielded human-readable keys for single-digit pull requests (`0-9`), any multi-digit PR number (e.g., PR #10) computed an invalid offset value (e.g., `48 + 10 = 58`), which translates to the Unicode character `":"`. This garbled lookup addresses across tracking maps, silently destroying the accuracy of multi-digit collaboration metrics, ownership distributions, and bus factor ratings without throwing panic failures. Fixes #320.

###  Root Cause Analysis (ASCII Visualization)
```text
PR #5:  5  + 48 ('0') = 53 -> string(rune(53)) -> "5"     [Accidental Success]
PR #10: 10 + 48 ('0') = 58 -> string(rune(58)) -> ":"     [CRITICAL CORRUPTION]
```
### Solution Implemented
Standardized Base-10 String Formatting: Eradicated the unsafe raw byte-offset calculations inside internal/analyzer/collaboration.go. Replaced the sequence entirely with an idiomatic, explicit string-formatting utility call: fmt.Sprintf("PR #%d", pr.Number).

Tabular Boundary Verification Suite: Authored a complete, localized verification framework inside internal/analyzer/collaboration_test.go to test map compilation across boundary conditions.

Comprehensive Coverage: Designed test definitions scanning single-digit records alongside deep multi-digit indexes (PR #12, PR #105) to ensure cross-contributor maps compile with complete legibility.

### Verification & Test Logs
Validated locally via Go's internal testing harness. All localized metrics processing engines pass cleanly:

TestAnalyzeCrossContributorPatterns/single_digit_PR_number: PASSED

TestAnalyzeCrossContributorPatterns/multi_digit_PR_number: PASSED

