### PR TITLE
fix: resolve goroutine leak and prevent divide-by-zero panic in progress indicators

### DIFF
--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -199,7 +199,10 @@ func (p *ProgressBar) display() {
 	}
 
 	barWidth := 30
-	filledWidth := (p.current * barWidth) / p.total
+	filledWidth := 0
+	if p.total > 0 {
+		filledWidth = (p.current * barWidth) / p.total
+	}
 	if p.current > 0 && filledWidth == 0 {
 		filledWidth = 1
 	}
@@ -407,6 +410,12 @@ func (o *OverallProgress) UpdateStep(stepMessage string) {
 func (o *OverallProgress) Finish() {
 	o.mu.Lock()
 	defer o.mu.Unlock()
+
+	// Signal the background ticker goroutine to stop if one is running
+	if o.stepDone != nil {
+		close(o.stepDone)
+		o.stepDone = nil
+	}
 
 	o.spinner.Stop()
 	elapsed := time.Since(o.startTime).Seconds()


### PR DESCRIPTION
This PR fixes two critical issues in the UI tracking components of the CLI (`internal/progress/progress.go`):

* **Fixed a goroutine leak in `OverallProgress.Finish()`:** The background ticker goroutine launched by `StartStep()` was never explicitly terminated if `Finish()` was called before `CompleteStep()` (e.g. on early returns or errors). I added a safety check to close the `stepDone` channel and cleanly exit the goroutine.
* **Prevented `divide-by-zero` panic in `ProgressBar`:** Added a guard clause in `display()` to ensure `p.total` is greater than `0` before calculating `filledWidth`. This prevents the CLI from fatally crashing if initialized with an empty task list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and error handling of progress tracking to provide more reliable operation monitoring across diverse use cases.
  * Enhanced resource cleanup and management during operation completion, ensuring all background monitoring processes are properly terminated to prevent resource leaks and enable cleaner application shutdown with improved system resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->