### PR TITLE
feat: implement PR velocity metric in trend analyzer

### DIFF
--- a/internal/analyzer/trends.go
+++ b/internal/analyzer/trends.go
@@ -152,7 +152,17 @@ func AnalyzeTrends(
 	}
 
 	for i := range metrics.MonthlyData {
-    metrics.MonthlyData[i].PRVelocity = CalculatePRVelocity(prs)
+    monthStart := metrics.MonthlyData[i].Month
+    monthEnd := monthStart.AddDate(0, 1, 0) // Adds one month
+
+    monthPRs := make([]github.PullRequest, 0)
+		for _, pr := range prs {
+			// Check if PR was created within this specific month
+			if !pr.CreatedAt.Before(monthStart) && pr.CreatedAt.Before(monthEnd) {
+				monthPRs = append(monthPRs, pr)
+			}
+		}
+		metrics.MonthlyData[i].PRVelocity = CalculatePRVelocity(monthPRs)
 	}
 	// Calculate current health score (simplified)
 	metrics.CurrentHealthScore = calculateCurrentHealthScore(commits, contributors, issues, prs)

--- a/internal/analyzer/trends.go
+++ b/internal/analyzer/trends.go
@@ -30,6 +30,7 @@ type MonthlyMetric struct {
 	IssuesClosed  int       `json:"issues_closed"`
 	PRsOpened     int       `json:"prs_opened"`
 	PRsMerged     int       `json:"prs_merged"`
+	PRVelocity    float64   `json:"pr_velocity"`
 	AvgCommitSize float64   `json:"avg_commit_size"`
 }
 
@@ -63,6 +64,7 @@ type TrendMetrics struct {
 	PRTrend       TrendIndicator `json:"pr_trend"`
 	PRMergeRate   float64        `json:"pr_merge_rate"`
 	PRTrendValues []int          `json:"pr_trend_values"`
+	PRVelocity    float64        `json:"pr_velocity"`
 
 	// Health Score Prediction
 	PredictedHealthScore int            `json:"predicted_health_score"`
@@ -72,6 +74,23 @@ type TrendMetrics struct {
 	// Overall Assessment
 	OverallTrend TrendIndicator `json:"overall_trend"`
 	Summary      string         `json:"summary"`
+}
+// CalculatePRVelocity computes how fast PRs are merged on average
+func CalculatePRVelocity(prs []github.PullRequest) float64 {
+    var totalDuration time.Duration
+    var mergedCount int
+
+    for _, pr := range prs {
+        if pr.MergedAt != nil && pr.CreatedAt.Before(*pr.MergedAt) {
+            totalDuration += pr.MergedAt.Sub(pr.CreatedAt)
+            mergedCount++
+        }
+    }
+
+    if mergedCount == 0 {
+        return 0
+    }
+    return totalDuration.Hours() / float64(mergedCount)
 }
 
 // AnalyzeTrends performs comprehensive trend analysis on a repository
@@ -107,6 +126,7 @@ func AnalyzeTrends(
 		return metrics.MonthlyData[i].Month.Before(metrics.MonthlyData[j].Month)
 	})
 
+
 	// Analyze commit trends
 	metrics.CommitTrend, metrics.CommitChangeRate, metrics.AvgCommitsPerMonth = AnalyzeCommitFrequencyTrends(metrics.MonthlyData)
 	for _, m := range metrics.MonthlyData {
@@ -131,6 +151,9 @@ func AnalyzeTrends(
 		metrics.PRTrendValues = append(metrics.PRTrendValues, m.PRsMerged)
 	}
 
+	for i := range metrics.MonthlyData {
+    metrics.MonthlyData[i].PRVelocity = CalculatePRVelocity(prs)
+	}
 	// Calculate current health score (simplified)
 	metrics.CurrentHealthScore = calculateCurrentHealthScore(commits, contributors, issues, prs)
 

--- a/internal/analyzer/trends.go
+++ b/internal/analyzer/trends.go
@@ -76,6 +76,8 @@ type TrendMetrics struct {
 	Summary      string         `json:"summary"`
 }
 // CalculatePRVelocity computes how fast PRs are merged on average
+// CalculatePRVelocity computes the average time (in hours) it takes for PRs to be merged.
+// It excludes unmerged PRs or PRs where the merge time is before the creation time.
 func CalculatePRVelocity(prs []github.PullRequest) float64 {
     var totalDuration time.Duration
     var mergedCount int

--- a/internal/analyzer/trends_test.go
+++ b/internal/analyzer/trends_test.go
@@ -1,0 +1,18 @@
+package analyzer
+
+import (
+	"testing"
+)
+
+func TestMonthlyMetricCalculation(t *testing.T) {
+	// 1. Setup your test data here
+	// 2. Call the function you want to test
+	// 3. Use an 'if' statement to check the result
+	
+	expectedCommits := 0
+	actualCommits := 0 // Replace with your function call
+	
+	if actualCommits != expectedCommits {
+		t.Errorf("Expected %d, got %d", expectedCommits, actualCommits)
+	}
+}

--- a/internal/analyzer/trends_test.go
+++ b/internal/analyzer/trends_test.go
@@ -3,21 +3,26 @@ package analyzer
 import (
 	"testing"
 	"time" // This fixes the "undefined: time" error
+
 	"github.com/agnivo988/Repo-lyzer/internal/github" // This fixes the "undefined: github" error
 )
-func TestCalculatePRVelocity(t *testing.T) {
-    now := time.Now()
-    // Create a PR that took exactly 24 hours to merge
-    createdAt := now.Add(-24 * time.Hour)
-    prs := []github.PullRequest{
-        {
-            CreatedAt: createdAt,
-            MergedAt:  &now,
-        },
-    }
 
-    velocity := CalculatePRVelocity(prs)
-    if velocity != 24.0 {
-        t.Errorf("Expected 24.0 hours, got %f", velocity)
-    }
+func TestCalculatePRVelocity(t *testing.T) {
+	now := time.Now()
+	// Create a PR that took exactly 24 hours to merge
+	createdAt := now.Add(-24 * time.Hour)
+	prs := []github.PullRequest{
+		{
+			CreatedAt: createdAt,
+			MergedAt:  &now,
+		},
+	}
+
+	velocity := CalculatePRVelocity(prs)
+	// Replace your old if block with this:
+	expected := 24.0
+	tolerance := 0.0001
+	if velocity < expected-tolerance || velocity > expected+tolerance {
+		t.Errorf("Expected ~24.0 hours, got %f", velocity)
+	}
 }

--- a/internal/analyzer/trends_test.go
+++ b/internal/analyzer/trends_test.go
@@ -2,17 +2,22 @@ package analyzer
 
 import (
 	"testing"
+	"time" // This fixes the "undefined: time" error
+	"github.com/agnivo988/Repo-lyzer/internal/github" // This fixes the "undefined: github" error
 )
+func TestCalculatePRVelocity(t *testing.T) {
+    now := time.Now()
+    // Create a PR that took exactly 24 hours to merge
+    createdAt := now.Add(-24 * time.Hour)
+    prs := []github.PullRequest{
+        {
+            CreatedAt: createdAt,
+            MergedAt:  &now,
+        },
+    }
 
-func TestMonthlyMetricCalculation(t *testing.T) {
-	// 1. Setup your test data here
-	// 2. Call the function you want to test
-	// 3. Use an 'if' statement to check the result
-	
-	expectedCommits := 0
-	actualCommits := 0 // Replace with your function call
-	
-	if actualCommits != expectedCommits {
-		t.Errorf("Expected %d, got %d", expectedCommits, actualCommits)
-	}
+    velocity := CalculatePRVelocity(prs)
+    if velocity != 24.0 {
+        t.Errorf("Expected 24.0 hours, got %f", velocity)
+    }
 }


### PR DESCRIPTION
This PR completes Phase 1 of the Trend Analysis feature.

Added PRVelocity field to MonthlyMetric struct.

Implemented CalculatePRVelocity helper function in trends.go.

Integrated PR velocity calculation into the AnalyzeTrends pipeline.

Added unit test in trends_test.go.

- Fixes #472"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trend reports now include a pull request velocity metric (average PR merge time in hours) tracked per month and surfaced in trend summaries; shows 0 when no qualifying PRs exist.

* **Tests**
  * Added unit test validating the PR velocity calculation produces expected average merge durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->