### PR TITLE
fix: handle GitHub secondary rate limit (403 + Retry-After)

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -127,6 +127,7 @@ func (c *Client) get(url string, target interface{}) error {
 			remaining := resp.Header.Get("X-RateLimit-Remaining")
 			resetTime := resp.Header.Get("X-RateLimit-Reset")
 
+			// Primary rate limit: X-RateLimit-Remaining is exhausted, or explicit 429.
 			if remaining == "0" || resp.StatusCode == 429 {
 				resetUnix, _ := strconv.ParseInt(resetTime, 10, 64)
 				resetAt := time.Unix(resetUnix, 0)
@@ -149,6 +150,28 @@ func (c *Client) get(url string, target interface{}) error {
 				// Authenticated: wait and retry
 				select {
 				case <-time.After(waitTime + time.Second):
+					continue
+				case <-c.ctx.Done():
+					return c.ctx.Err()
+				}
+			}
+
+			// Secondary rate limit: GitHub returns 403 with a Retry-After header
+			// (primary quota is not exhausted, so remaining != "0").
+			// See: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#about-secondary-rate-limits
+			if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+				waitSecs, err := strconv.Atoi(retryAfter)
+				if err != nil || waitSecs <= 0 {
+					waitSecs = 60 // safe default per GitHub guidance
+				}
+				waitTime := time.Duration(waitSecs) * time.Second
+
+				resp.Body.Close()
+				if attempt == maxRetries {
+					return fmt.Errorf("GitHub secondary rate limit exceeded; retry after %s", formatDuration(waitTime))
+				}
+				select {
+				case <-time.After(waitTime):
 					continue
 				case <-c.ctx.Done():
 					return c.ctx.Err()

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -43,6 +44,71 @@ func TestGet_RetriesOnServerError(t *testing.T) {
 	}
 	if atomic.LoadInt32(&calls) < 3 {
 		t.Fatalf("expected at least 3 calls, got %d", calls)
+	}
+}
+
+// Test that a 403 with Retry-After (secondary rate limit) is retried after waiting
+func TestGet_RetriesOnSecondaryRateLimit(t *testing.T) {
+	var calls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			// Simulate GitHub secondary rate limit: 403 + Retry-After, remaining is NOT 0
+			w.Header().Set("X-RateLimit-Remaining", "50")
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "secondary rate limit", http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"login": "secondary", "name": "Secondary"})
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.http = srv.Client()
+	c.SetToken("fake-token")
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	c.SetContext(ctx)
+
+	var u User
+	start := time.Now()
+	if err := c.get(srv.URL+"/user", &u); err != nil {
+		t.Fatalf("expected success after secondary rate-limit wait, got err: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 1*time.Second {
+		t.Fatalf("expected to wait at least 1s for Retry-After, waited %v", elapsed)
+	}
+	if u.Login != "secondary" {
+		t.Fatalf("expected login secondary, got %q", u.Login)
+	}
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("expected at least 2 calls, got %d", calls)
+	}
+}
+
+// Test that a genuine 403 (no Retry-After, no rate-limit headers) returns access forbidden error
+func TestGet_ForbiddenWithoutRetryAfterReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Pure 403 — no Retry-After, remaining is non-zero
+		w.Header().Set("X-RateLimit-Remaining", "50")
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.http = srv.Client()
+	c.SetToken("fake-token")
+
+	var u User
+	err := c.get(srv.URL+"/user", &u)
+	if err == nil {
+		t.Fatal("expected error for genuine 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "access forbidden") {
+		t.Fatalf("expected 'access forbidden' in error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Previously, 403 responses carrying a Retry-After header were misclassified as access-forbidden errors. GitHub uses this combination to signal secondary rate limits (concurrency/abuse detection), which are separate from primary quota exhaustion (X-RateLimit-Remaining: 0).

The client now reads Retry-After on any 403, waits the specified duration (defaulting to 60 s when the value is absent or unparseable), then retries — consistent with how primary rate limits are already handled. A genuine 403 with no Retry-After still returns the original access-forbidden error.

Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of GitHub API secondary rate limit errors by implementing automatic retry logic with appropriate wait times, improving the application's resilience when dealing with rate-limited API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->