### PR TITLE
fix: reject .. and . segments in sanitizeRepoPath

### DIFF
--- a/internal/ui/file_edit.go
+++ b/internal/ui/file_edit.go
@@ -263,6 +263,11 @@ func sanitizeRepoPath(filePath string) (string, error) {
 			continue
 		}
 
+		// Reject path traversal segments before any other check.
+		if p == ".." || p == "." {
+			return "", fmt.Errorf("invalid file path")
+		}
+
 		for _, r := range p {
 			if unicode.IsControl(r) {
 				return "", fmt.Errorf("invalid file path")

--- a/internal/ui/file_edit_security_test.go
+++ b/internal/ui/file_edit_security_test.go
@@ -92,3 +92,60 @@ func TestSanitizeRepoPath_RemovesExtraSeparatorsAndEscapes(t *testing.T) {
 		t.Fatalf("sanitizeRepoPath() retained duplicate separators: %q", got)
 	}
 }
+
+func TestSanitizeRepoPath_RejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"double dot segment", "../../cmd/root.go"},
+		{"double dot in middle", "cmd/../../root.go"},
+		{"double dot at end", "cmd/.."},
+		{"bare double dot", ".."},
+		{"single dot segment", "./cmd/root.go"},
+		{"bare single dot", "."},
+		{"single dot in middle", "cmd/./root.go"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := sanitizeRepoPath(tc.path)
+			if err == nil {
+				t.Fatalf("sanitizeRepoPath(%q) expected error for path traversal, got nil", tc.path)
+			}
+		})
+	}
+}
+
+func TestSanitizeRepoPath_AcceptsValidPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"simple file", "cmd/root.go", "cmd/root.go"},
+		{"nested path", "internal/github/client.go", "internal/github/client.go"},
+		{"file with dots in name", "v1.2.3/CHANGELOG.md", "v1.2.3/CHANGELOG.md"},
+		{"leading slash stripped", "/cmd/root.go", "cmd/root.go"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := sanitizeRepoPath(tc.path)
+			if err != nil {
+				t.Fatalf("sanitizeRepoPath(%q) unexpected error: %v", tc.path, err)
+			}
+			if got != tc.want {
+				t.Fatalf("sanitizeRepoPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
sanitizeRepoPath blocked control characters but allowed .. and . segments through unchecked. path.Join() in the callers then silently resolved traversal — e.g. owner/repo/blob/main/../../cmd/root.go — producing a URL pointing to a completely different file.

Add an explicit guard before the control-character loop so any .. or . segment returns an error immediately, consistent with how the function already treats empty segments and control characters.

Closes #471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file path validation to prevent path traversal attacks by rejecting potentially unsafe path segments.

* **Tests**
  * Added comprehensive test coverage for file path validation, including path traversal patterns and valid path normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->