### PR TITLE
fix: validate trends months flag

### DIFF
--- a/cmd/trends.go
+++ b/cmd/trends.go
@@ -86,14 +86,10 @@ func runTrends(repoArg string, cmd *cobra.Command) error {
 	demoFlag, _ := cmd.Flags().GetBool("demo")
 	modelFlag, _ := cmd.Flags().GetString("model")
 
-	// Use months flag or default
+	if err := validateMonths(monthsFlag); err != nil {
+		return err
+	}
 	months := monthsFlag
-	if months < 1 {
-		months = 6 // Default to 6 months
-	}
-	if months > 24 {
-		months = 24 // Max 24 months
-	}
 
 	// Track detailed flag (for future use)
 	_ = detailedFlag
@@ -176,6 +172,13 @@ func runTrends(repoArg string, cmd *cobra.Command) error {
 		fmt.Printf("\nAnalysis completed in %v\n", duration)
 	}
 
+	return nil
+}
+
+func validateMonths(months int) error {
+	if months < 1 || months > 24 {
+		return fmt.Errorf("months must be between 1 and 24, got %d", months)
+	}
 	return nil
 }
 

--- a/cmd/trends_test.go
+++ b/cmd/trends_test.go
@@ -13,6 +13,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestValidateMonths(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int
+		want  bool
+	}{
+		{name: "minimum", value: 1, want: true},
+		{name: "maximum", value: 24, want: true},
+		{name: "zero", value: 0, want: false},
+		{name: "negative", value: -6, want: false},
+		{name: "above maximum", value: 25, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := validateMonths(test.value) == nil
+			if got != test.want {
+				t.Fatalf("validateMonths(%d) valid = %v, want %v", test.value, got, test.want)
+			}
+		})
+	}
+}
+
 func TestRunTrendsForecastOutputsJSON(t *testing.T) {
 	originalBuildTimeline := buildTimelineFromGitHub
 	originalForecast := forecastHealthFromTimeline


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trend commands now reject month values outside the supported range of 1–24.
  * Invalid values return a clear validation error instead of being silently adjusted.

* **Tests**
  * Added coverage for valid boundary values and invalid month inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->