### PR TITLE
docs: fix project structure link

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The `docker-compose.yml` mounts a local `./data` directory to persist settings a
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) – Complete architecture guide  
 - [ANALYZER_INTEGRATION.md](docs/ANALYZER_INTEGRATION.md) – Adding new analyzers  
 - [IMPLEMENTATION_DETAILS.md](docs/IMPLEMENTATION_DETAILS.md) – Technical deep dive
-- [PROJECT STRUCTURE.md](docs/PROJECT_STRUCTURE.md) - Project Structure and Workflow
+- [PROJECT STRUCTURE.md](docs/PROJECT%20STRUCTURE.md) - Project Structure and Workflow
 
 ### Reference
 - [DOCUMENTATION_INDEX.md](docs/DOCUMENTATION_INDEX.md) – Master index  


### PR DESCRIPTION
## Description

Fixed the broken Markdown link for `PROJECT STRUCTURE.md` by properly encoding the space in the file path.

## Type of Change

* [x] Documentation update

## Changes Made

* Fixed the `PROJECT STRUCTURE.md` link in `README.md`.
* No code or functionality was changed.

## Testing

* Verified the updated Markdown link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed the contributor documentation link so it opens correctly when the referenced filename contains spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->