### PR TITLE
Fix: handle spaces in requirements.txt version comparators

### DIFF
--- a/internal/analyzer/dependencies.go
+++ b/internal/analyzer/dependencies.go
@@ -349,7 +349,7 @@ func parseRequirementsTxt(content []byte) ([]Dependency, string) {
 	// Group 1: Name (including dots and dashes, but excluding extras)
 	// Group 2: Version specifier
 	// Group 3: Optional markers (after ;)
-	versionPattern := regexp.MustCompile(`^([a-zA-Z0-9._\-]+)(?:\[[^\]]+\])?\s*([=<>!~]+[^;#\s]+)?(?:\s*;\s*([^#]+))?`)
+	versionPattern := regexp.MustCompile(`^([a-zA-Z0-9._\-]+)(?:\[[^\]]+\])?\s*([=<>!~]+\s*[^;#\s]+)?(?:\s*;\s*([^#]+))?`)
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)

--- a/internal/analyzer/dependencies_test.go
+++ b/internal/analyzer/dependencies_test.go
@@ -46,6 +46,34 @@ func TestParseRequirementsTxt(t *testing.T) {
 				{Name: "requests", Version: "==2.28.0", Type: "production"},
 			},
 		},
+		{
+			name:    "Package with space after comparator (>= )",
+			content: "numpy >= 1.0",
+			expected: []Dependency{
+				{Name: "numpy", Version: ">= 1.0", Type: "production"},
+			},
+		},
+		{
+			name:    "Package with space after comparator (== )",
+			content: "flask == 2.0.0",
+			expected: []Dependency{
+				{Name: "flask", Version: "== 2.0.0", Type: "production"},
+			},
+		},
+		{
+			name:    "Package with space after comparator (!= )",
+			content: "requests != 2.0.0",
+			expected: []Dependency{
+				{Name: "requests", Version: "!= 2.0.0", Type: "production"},
+			},
+		},
+		{
+			name:    "Package with space after comparator (<= )",
+			content: "numpy <= 1.20",
+			expected: []Dependency{
+				{Name: "numpy", Version: "<= 1.20", Type: "production"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/analyzer/dependencies_test.go
+++ b/internal/analyzer/dependencies_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// TestParseRequirementsTxt tests the parsing of Python requirements.txt files
+// with various version specifier formats including spaced comparators.
 func TestParseRequirementsTxt(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -100,6 +102,8 @@ func TestParseRequirementsTxt(t *testing.T) {
 	}
 }
 
+// TestParseCargoToml tests the parsing of Rust Cargo.toml files
+// with both simple and inline table dependency formats.
 func TestParseCargoToml(t *testing.T) {
 	content := `
 [dependencies]

--- a/internal/analyzer/dependencies_test.go
+++ b/internal/analyzer/dependencies_test.go
@@ -74,6 +74,20 @@ func TestParseRequirementsTxt(t *testing.T) {
 				{Name: "numpy", Version: "<= 1.20", Type: "production"},
 			},
 		},
+		{
+			name:    "Package with space after compatible release comparator (~= )",
+			content: "requests ~= 2.28.0",
+			expected: []Dependency{
+				{Name: "requests", Version: "~= 2.28.0", Type: "production"},
+			},
+		},
+		{
+			name:    "Package with space after arbitrary equality comparator (=== )",
+			content: "numpy === 1.20.0",
+			expected: []Dependency{
+				{Name: "numpy", Version: "=== 1.20.0", Type: "production"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What
- Fix regex in `parseRequirementsTxt` to allow optional whitespace after comparators (>=, ==, !=, <=, ~=, ===)
- Add test cases for spaced comparators

## Why
- Fixes #554
- The regex `([=<>!~]+[^;#\s]+)` was dropping version constraints when a space followed the comparator (e.g., `numpy >= 1.0` became `numpy == *`)
- This silently caused incorrect dependency analysis, vulnerability scanning, and compatibility checks

## Changes
- `internal/analyzer/dependencies.go` - Updated regex to `([=<>!~]+\s*[^;#\s]+)` to allow optional whitespace
- `internal/analyzer/dependencies_test.go` - Added 6 test cases for spaced comparators (>=, ==, !=, <=, ~=, ===)

## Testing
- All existing tests pass
- New test cases verify spaced comparator parsing works correctly
- Tested with: `go test ./internal/analyzer/ -run TestParseRequirementsTxt -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of Python dependency requirements that include spaces between version comparison operators and version numbers.
  * Added support for expressions such as `>= 1.0.0`, `== 2.28.0`, and similar formats.

* **Tests**
  * Added coverage for multiple spaced comparison operators to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->