### PR TITLE
Fix: correct Go version and action versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.24"
       - name: Cache Go modules
         uses: actions/cache@v5
         with:
@@ -35,11 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.24"
       - name: Cache Go modules
         uses: actions/cache@v5
         with:
@@ -57,13 +57,13 @@ jobs:
     needs: build
     if: github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all history for tags
+          fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.24"
       - name: Cache Go modules
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
## What
- Fix Go version in CI workflow from 1.25 to 1.24
- Fix action versions from @v6 (non-existent) to @v4/@v5

## Why
- Fixes #555
- Go 1.25 does not exist (current latest is 1.24.x)
- `actions/checkout@v6` and `actions/setup-go@v6` do not exist
- CI pipeline was completely broken - no tests or builds could pass
- Aligns with `release.yml` and `go.mod` which correctly use Go 1.24

## Changes
- `.github/workflows/ci.yml` - Updated Go version and action versions across all jobs (test, build, release)

## Testing
- CI workflow should now successfully run tests and builds
- Verified version alignment with `go.mod` (go 1.24.2) and `release.yml` (go-version: 1.24)
