### PR TITLE
Fix: replace deprecated strings.Title with manual capitalization

### DIFF
--- a/cmd/trends.go
+++ b/cmd/trends.go
@@ -253,8 +253,8 @@ func runTrendsForecast(owner, repo string, months int, modelName string, jsonFla
 	// Overall trend label from forecast
 	trendLabel := "Stable"
 	if forecast.Trend != "" {
-		// capitalize
-		trendLabel = strings.Title(forecast.Trend)
+		// capitalize first letter
+		trendLabel = strings.ToUpper(forecast.Trend[:1]) + forecast.Trend[1:]
 	}
 	fmt.Printf("Trend: %s\n\n", trendLabel)
 


### PR DESCRIPTION
## What
- Replace deprecated `strings.Title()` with manual first-character capitalization

## Why
- Fixes #556
- `strings.Title()` has been deprecated since Go 1.18
- It incorrectly title-cases every word (e.g., "increasing trend" becomes "Increasing Trend")
- The intent was only to capitalize the first letter of the trend label

## Changes
- `cmd/trends.go` - Replaced `strings.Title(forecast.Trend)` with `strings.ToUpper(forecast.Trend[:1]) + forecast.Trend[1:]`

## Testing
- Build succeeds: `go build ./...`
- Behavior unchanged for single-word trend labels
