### PR TITLE
Add: pagination support for GitHub issues API

### DIFF
--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"time"
 
 	gocache "github.com/patrickmn/go-cache"
@@ -24,6 +25,8 @@ type Issue struct {
 	User        User         `json:"user"`
 }
 
+// GetIssues fetches all issues for a repository with pagination
+// state can be "open", "closed", or "all"
 func (c *Client) GetIssues(owner, repo string, state string) ([]Issue, error) {
 	cacheKey := "issues:" + owner + "/" + repo + ":" + state
 	if cached, found := c.cache.Get(cacheKey); found {
@@ -35,14 +38,39 @@ func (c *Client) GetIssues(owner, repo string, state string) ([]Issue, error) {
 			return copyIssues(cached.([]Issue)), nil
 		}
 
-		var issues []Issue
-		url := "https://api.github.com/repos/" + owner + "/" + repo + "/issues?state=" + state + "&per_page=100"
-		if err := c.get(url, &issues); err != nil {
-			return nil, err
+		var allIssues []Issue
+
+		page := 1
+		perPage := 100
+
+		for {
+			url := fmt.Sprintf(
+				"https://api.github.com/repos/%s/%s/issues?state=%s&per_page=%d&page=%d",
+				owner, repo, state, perPage, page,
+			)
+
+			var issues []Issue
+			if err := c.get(url, &issues); err != nil {
+				return nil, err
+			}
+
+			// Stop when no more issues
+			if len(issues) == 0 {
+				break
+			}
+
+			allIssues = append(allIssues, issues...)
+
+			// Stop when fewer than per_page (last page)
+			if len(issues) < perPage {
+				break
+			}
+
+			page++
 		}
 
-		c.cache.Set(cacheKey, issues, gocache.DefaultExpiration)
-		return copyIssues(issues), nil
+		c.cache.Set(cacheKey, allIssues, gocache.DefaultExpiration)
+		return copyIssues(allIssues), nil
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What
- Add pagination support to `GetIssues` to fetch all issues instead of just the first page

## Why
- Fixes #557
- Previously, `GetIssues` only fetched page 1 (max 100 issues)
- Repositories with 100+ issues had incomplete data
- This affected trend analysis, contribution scoring, and PR analytics (GitHub issues API includes PRs)
- Other methods like `GetPullRequests` and `GetCommits` already had pagination

## Changes
- `internal/github/issues.go` - Replaced single-page fetch with pagination loop following existing patterns

## Testing
- Build succeeds: `go build ./...`
- Follows same pagination pattern as `GetPullRequests` and `GetCommits`
