### PR TITLE
Fix: broken fileKey generation for PR numbers > 9

### DIFF
--- a/internal/analyzer/collaboration.go
+++ b/internal/analyzer/collaboration.go
@@ -3,6 +3,7 @@
 package analyzer
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -208,7 +209,7 @@ func analyzeCrossContributorPatterns(prs []github.PullRequest) CrossContributorP
 
 		// Create a "virtual" file entry per PR for analysis
 		// In production, we'd use commit file data
-		fileKey := "PR #" + string(rune(pr.Number+'0'))
+		fileKey := fmt.Sprintf("PR #%d", pr.Number)
 		if fileContributors[fileKey] == nil {
 			fileContributors[fileKey] = make(map[string]bool)
 		}


### PR DESCRIPTION
## What
- Fix broken `fileKey` generation in `analyzeCrossContributorPatterns`

## Why
- Fixes #561
- `string(rune(pr.Number+'0'))` only works for PRs 1-9
- PR #10 becomes `":"`, PR #100 becomes garbled Unicode
- Cross-contributor analysis was completely broken for most repositories

## Changes
- `internal/analyzer/collaboration.go` - Replaced with `fmt.Sprintf("PR #%d", pr.Number)`

## Testing
- Build succeeds: `go build ./...`
- Now correctly generates "PR #10", "PR #100", etc.
