### PR TITLE
Fix: countRecentCommits now filters by 90-day cutoff

### DIFF
--- a/internal/analyzer/quality_dashboard.go
+++ b/internal/analyzer/quality_dashboard.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/agnivo988/Repo-lyzer/internal/github"
 )
@@ -307,9 +308,14 @@ func generateDashboardRecommendations(
 }
 
 func countRecentCommits(commits []github.Commit) int {
-	// This is a simplified version - in practice you'd check commit dates
-	// For now, we'll assume all commits in the slice are recent
-	return len(commits)
+	cutoff := time.Now().AddDate(0, 0, -90)
+	count := 0
+	for _, c := range commits {
+		if c.Commit.Author.Date.After(cutoff) {
+			count++
+		}
+	}
+	return count
 }
 
 // GetRiskLevelColor returns color styling for risk level


### PR DESCRIPTION
## What
- Fix `countRecentCommits` to actually filter commits by date

## Why
- Fixes #563
- Previously returned all commits regardless of date
- "No commits in last 90 days" hotspot never triggered
- Could not detect abandoned repositories

## Changes
- `internal/analyzer/quality_dashboard.go` - Added 90-day cutoff filter using `Commit.Author.Date`

## Testing
- Build succeeds: `go build ./...`
- Now correctly counts only recent commits
