### PR TITLE
Fix: remove unreachable dead code in summary.go and analyze.go

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -63,10 +63,6 @@ func validateRepoURL(repoArg string) (owner, repo string, err error) {
 		return "", "", fmt.Errorf("owner name is too long (maximum 39 characters)")
 	}
 
-	if len(owner) < 1 {
-		return "", "", fmt.Errorf("owner name is too short (minimum 1 character)")
-	}
-
 	if strings.HasPrefix(owner, "-") || strings.HasSuffix(owner, "-") {
 		return "", "", fmt.Errorf("owner name cannot start or end with a hyphen")
 	}
@@ -84,10 +80,6 @@ func validateRepoURL(repoArg string) (owner, repo string, err error) {
 
 	if len(repo) > 100 {
 		return "", "", fmt.Errorf("repository name is too long (maximum 100 characters)")
-	}
-
-	if len(repo) < 1 {
-		return "", "", fmt.Errorf("repository name is too short (minimum 1 character)")
 	}
 
 	// Repository names can contain more characters than usernames

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -43,11 +43,6 @@ Examples:
 			fmt.Println("Usage:   repo-lyzer summary <repository>")
 			fmt.Println("Example: repo-lyzer summary golang/go")
 			return fmt.Errorf("repository name required")
-		} else if len(args) > 1 {
-			fmt.Println("Error: too many arguments provided.")
-			fmt.Println("Usage:   repo-lyzer summary <repository>")
-			fmt.Println("Example: repo-lyzer summary golang/go")
-			return fmt.Errorf("too many arguments: expected 1, got %d", len(args))
 		}
 
 		// Validate the repository URL format


### PR DESCRIPTION
## What
- Remove unreachable dead code in `cmd/summary.go` and `cmd/analyze.go`

## Why
- Fixes #565
- `summary.go`: `else if len(args) > 1` unreachable after `len(args) != 1` return
- `analyze.go`: `len(owner) < 1` unreachable after `owner == ""` check
- `analyze.go`: `len(repo) < 1` unreachable after `repo == ""` check

## Changes
- `cmd/summary.go` - Removed unreachable `else if` branch
- `cmd/analyze.go` - Removed two unreachable length checks

## Testing
- Build succeeds: `go build ./...`
- No behavior change - dead code removal only
