### PR TITLE
Fix: CSV export header says Lines of Code but writes percentages

### DIFF
--- a/internal/ui/export.go
+++ b/internal/ui/export.go
@@ -365,7 +365,7 @@ func ExportCSV(data AnalysisResult, _ string) (string, error) {
 
 	// Languages
 	file.WriteString("\nLanguages\n")
-	file.WriteString("Language,Lines of Code\n")
+	file.WriteString("Language,Percentage\n")
 	total := 0
 	for _, bytes := range data.Languages {
 		total += bytes


### PR DESCRIPTION
## What
- Fix CSV export header to match actual data

## Why
- Fixes #569
- Header said "Lines of Code" but data was percentages
- Misleading for anyone reading the CSV export

## Changes
- `internal/ui/export.go` - Changed header from "Lines of Code" to "Percentage"

## Testing
- Build succeeds: `go build ./...`
- CSV export now shows correct header
