### PR TITLE
Fix: deep copy pointer fields in cache copy functions

### DIFF
--- a/internal/github/cachecopy.go
+++ b/internal/github/cachecopy.go
@@ -1,8 +1,16 @@
 package github
 
+import "time"
+
 func copyCommits(src []Commit) []Commit {
 	out := make([]Commit, len(src))
-	copy(out, src)
+	for i, c := range src {
+		out[i] = c
+		if c.Author != nil {
+			authorCopy := *c.Author
+			out[i].Author = &authorCopy
+		}
+	}
 	return out
 }
 
@@ -14,7 +22,17 @@ func copyContributors(src []Contributor) []Contributor {
 
 func copyIssues(src []Issue) []Issue {
 	out := make([]Issue, len(src))
-	copy(out, src)
+	for i, issue := range src {
+		out[i] = issue
+		if issue.ClosedAt != nil {
+			closedCopy := *issue.ClosedAt
+			out[i].ClosedAt = &closedCopy
+		}
+		if issue.PullRequest != nil {
+			prCopy := *issue.PullRequest
+			out[i].PullRequest = &prCopy
+		}
+	}
 	return out
 }
 
@@ -28,7 +46,17 @@ func copyLanguagesMap(src map[string]int) map[string]int {
 
 func copyPullRequests(src []PullRequest) []PullRequest {
 	out := make([]PullRequest, len(src))
-	copy(out, src)
+	for i, pr := range src {
+		out[i] = pr
+		if pr.MergedAt != nil {
+			mergedCopy := *pr.MergedAt
+			out[i].MergedAt = &mergedCopy
+		}
+		if pr.ClosedAt != nil {
+			closedCopy := *pr.ClosedAt
+			out[i].ClosedAt = &closedCopy
+		}
+	}
 	return out
 }
 
@@ -42,4 +70,12 @@ func copyTreeEntries(src []TreeEntry) []TreeEntry {
 	out := make([]TreeEntry, len(src))
 	copy(out, src)
 	return out
+}
+
+func copyTime(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	copy := *t
+	return &copy
 }


### PR DESCRIPTION
## What
- Deep copy pointer fields in cache copy functions

## Why
- Fixes #573
- Shallow copy shared pointer fields between original and copy
- Mutations to copies affected cached originals

## Changes
- `internal/github/cachecopy.go` - Added deep copy for `Commit.Author`, `Issue.ClosedAt`, `Issue.PullRequest`, `PullRequest.MergedAt`, `PullRequest.ClosedAt`

## Testing
- Build succeeds: `go build ./...`
- Cache copies are now independent from originals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of cached commit, issue, and pull request data.
  * Prevented unintended sharing of date and referenced field values, helping ensure cached information remains accurate and isolated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->