### PR TITLE
Fix: track block comments in complexity calculation

### DIFF
--- a/internal/analyzer/hotspots.go
+++ b/internal/analyzer/hotspots.go
@@ -200,10 +200,29 @@ func calculateComplexity(content, filename string) int {
 	}
 
 	lines := strings.Split(content, "\n")
+	inBlockComment := false
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
+
+		// Handle block comments
+		if inBlockComment {
+			if strings.Contains(trimmed, "*/") {
+				inBlockComment = false
+			}
+			continue
+		}
+
+		// Check for start of block comment
+		if strings.Contains(trimmed, "/*") {
+			if !strings.Contains(trimmed, "*/") {
+				inBlockComment = true
+			}
+			continue
+		}
+
+		// Skip single-line comments
 		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
-			continue // Skip comments (basic check)
+			continue
 		}
 
 		for _, kw := range keywords {


### PR DESCRIPTION
## What
- Track block comments `/* ... */` in complexity calculation

## Why
- Fixes #577
- Code inside block comments was counted as complexity
- Inflated hotspot scores for C, Java, JS, CSS files

## Changes
- `internal/analyzer/hotspots.go` - Added `inBlockComment` state tracking

## Testing
- Build succeeds: `go build ./...`
- Block comments now properly excluded from complexity
