### PR TITLE
Fix: notifications command now works for first-time users

### DIFF
--- a/cmd/notifications.go
+++ b/cmd/notifications.go
@@ -39,13 +39,14 @@ Examples:
 			return err
 		}
 
-		config, err := config.LoadSettings()
+		appConfig, err := config.LoadSettings()
 		if err != nil {
-			return err
+			// If settings file doesn't exist, use defaults
+			appConfig = config.DefaultSettings()
 		}
 
 		// Create main model and set to notifications state
-		model := ui.NewMainModel(cache, config)
+		model := ui.NewMainModel(cache, appConfig)
 		model.SetStateNotifications()
 
 		// Run the TUI


### PR DESCRIPTION
## What
- Fix notifications command to work for first-time users

## Why
- Fixes #579
- `LoadSettings()` returned error when settings file didn't exist
- First-time users got an error instead of empty notifications view

## Changes
- `cmd/notifications.go` - Use default settings when `LoadSettings()` fails

## Testing
- Build succeeds: `go build ./...`
- Notifications command now works for first-time users
